### PR TITLE
Adjust Abydos Zapolite-poor Magma Molten Destabilization Recipe

### DIFF
--- a/kubejs/server_scripts/endgame content/abydos_lines/magma_and_ore_decomp.js
+++ b/kubejs/server_scripts/endgame content/abydos_lines/magma_and_ore_decomp.js
@@ -44,7 +44,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.UV]*.8);
 
     event.recipes.gtceu.molten_destabilizing(id('abydos_zapolite_poor_magma'))
-        .inputFluids('gtceu:abydos_zapolite_poor_magma 6000')
+        .inputFluids('gtceu:abydos_zapolite_poor_magma 60000')
         .outputFluids('gtceu:zapolite 1500',
             'gtceu:molten_ore_mixture 800',
             'gtceu:crookesite 875',


### PR DESCRIPTION
This PR fixes the inconsistency between **Zapolite-poor Magma** and **Titanite-poor Magma** processing.

* Zapolite-poor Magma Molten Destabilization provides ~57.95B of material back, from only 6B input.
* Titanite-poor Magma Molten Destabilization provides 58B back, from 60B input.

I assume this discrepancy is unintended, likely a simple typo.

<img width="404" height="596" alt="2025-09-10 01-30-21" src="https://github.com/user-attachments/assets/b077d2f4-1cdd-458b-984e-b7ac5091b1d3" /> <img width="393" height="584" alt="2025-09-10 01-53-11" src="https://github.com/user-attachments/assets/129071a9-78df-4dfb-8ec9-d6722412126d" />
