### PR TITLE
Use /usr/bin/env bash for portable shebang

### DIFF
--- a/packmode_picker.sh
+++ b/packmode_picker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Enable colors
 GREEN="\033[0;36m"


### PR DESCRIPTION
What
Switches shebang from /bin/bash to /usr/bin/env bash.

Why
/bin/bash doesn't work on NixOS or other exotic distros.

Scope
No runtime behavior will change beyond interpreter resolution.