### PR TITLE
Glycerol chem plant recipe

### DIFF
--- a/kubejs/server_scripts/multiblock recipes/chemical_plant.js
+++ b/kubejs/server_scripts/multiblock recipes/chemical_plant.js
@@ -170,4 +170,11 @@ ServerEvents.recipes(event => {
         .duration(100)
         .EUt(GTValues.VHA[GTValues.LuV]);
 
+    event.recipes.gtceu.chemical_skip(id('glycerol_skip'))
+        .itemInputs('gtceu:carbon_dust 3')
+        .inputFluids('gtceu:hydrogen 8000', 'gtceu:oxygen 3000')
+        .outputFluids('gtceu:glycerol 1000')
+        .duration(200)
+        .EUt(GTValues.VHA[GTValues.LuV]);
+
 });


### PR DESCRIPTION
Adds a glycerol recipe to chem plant skips. There should be no recipe conflicts.
Glycerol could be added to bacteria, but we have no free slots and we'd need 2 more substances to warrant a new bacteria.