### PR TITLE
Fixed reference to gtceu:sand

### DIFF
--- a/kubejs/server_scripts/HM/pre-lv/other_pre-cobble.js
+++ b/kubejs/server_scripts/HM/pre-lv/other_pre-cobble.js
@@ -265,7 +265,7 @@ ServerEvents.recipes(event => {
 	event.smelting(`kubejs:charcoal_pellet`, `#minecraft:logs_that_burn`).id('kjs:smelting/charcoal_pellet_manual_only').id('start:smelting/charcoal_pellet');
 	event.recipes.create.crushing(['2x kubejs:charcoal_pellet', Item.of('kubejs:charcoal_pellet').withChance(0.5)], 'minecraft:charcoal');
 	event.recipes.create.milling(['gtceu:charcoal_dust'], 'minecraft:charcoal');
-	event.recipes.create.milling(['gtceu:sand'], 'minecraft:gravel');
+	event.recipes.create.milling(['minecraft:sand'], 'minecraft:gravel');
 	event.recipes.create.milling(['exnihilosequentia:dust'], 'minecraft:sand');
 
 	event.remove({ id: 'thermal:rubber_3' });


### PR DESCRIPTION
This prevents pre-crushing-wheel cobbleworks setups from being able to automate sand in hardmode, which is currently causing me issues as I play through the pack.

There is a solid chance that I am missing something here, but as far as I can tell gtceu:sand doesn't exist, which would explain why I can't see the recipe in EMI in-game.