### PR TITLE
Eta-3 Bulk Laser Engrave

### DIFF
--- a/kubejs/server_scripts/endgame content/circuits.js
+++ b/kubejs/server_scripts/endgame content/circuits.js
@@ -262,7 +262,7 @@ ServerEvents.recipes(event => {
         const lensType = (LensIsTag == true) ? `#forge:lenses/${Lens}` : `gtceu:${Lens}_lens` ;
     
         event.recipes.gtceu.mass_laser_engraving(id(`mass_engrave_${output}`))
-            .itemInputs(`gtceu:${input}`)
+            .itemInputs(`64x gtceu:${input}`)
             .notConsumable(lensType)
             .itemOutputs(`${quantity * 64}x gtceu:${output}`)
             .duration(duration * 48)


### PR DESCRIPTION
This PR adjusts the `MassNonWaferEngraving` method to 64x inputs like other _Bulk Laser Engraver_ recipes.
I assume the massively overpowered recipes are an oversight.

<img width="398" height="302" alt="2025-10-21 04-00-11" src="https://github.com/user-attachments/assets/8f7cd076-4704-4ae0-b902-919dc2258e0b" />
<img width="386" height="305" alt="2025-10-21 04-00-18" src="https://github.com/user-attachments/assets/8924fb94-ef34-47a3-8698-7a05610031b8" />
<img width="383" height="298" alt="2025-10-21 04-08-48" src="https://github.com/user-attachments/assets/3b9be204-f06a-414a-8d33-7b4e419e8555" />
<img width="387" height="285" alt="2025-10-21 04-08-33" src="https://github.com/user-attachments/assets/11465592-dcc6-4aca-b3e9-dbf679a41094" />