### PR TITLE
Colossal-Chest-Protection

### DIFF
--- a/config/colossalchests-common.toml
+++ b/config/colossalchests-common.toml
@@ -49,5 +49,5 @@
 
 	[machine.colossal_chest]
 		#The maximum size a colossal chest can have.
-		maxSize = 20
+		maxSize = 5
 

--- a/kubejs/assets/colossalchests/lang/en_us.json
+++ b/kubejs/assets/colossalchests/lang/en_us.json
@@ -1,9 +1,3 @@
 {
-    "item.colossalchests.colossal_chest_wood.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons.",
-    "item.colossalchests.colossal_chest_copper.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons.",
-    "item.colossalchests.colossal_chest_iron.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons.",
-    "item.colossalchests.colossal_chest_silver.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons.",
-    "item.colossalchests.colossal_chest_gold.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons.",
-    "item.colossalchests.colossal_chest_diamond.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons.",
-    "item.colossalchests.colossal_chest_obsidian.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons."
+    "item.colossalchests.colossal_chest.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons."
 }

--- a/kubejs/assets/colossalchests/lang/en_us.json
+++ b/kubejs/assets/colossalchests/lang/en_us.json
@@ -1,0 +1,9 @@
+{
+    "item.colossalchests.colossal_chest_wood.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons.",
+    "item.colossalchests.colossal_chest_copper.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons.",
+    "item.colossalchests.colossal_chest_iron.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons.",
+    "item.colossalchests.colossal_chest_silver.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons.",
+    "item.colossalchests.colossal_chest_gold.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons.",
+    "item.colossalchests.colossal_chest_diamond.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons.",
+    "item.colossalchests.colossal_chest_obsidian.tooltip": "Please note that max size is 5x5x5 in this pack due to performance reasons."
+}

--- a/kubejs/client_scripts/common/tooltips.js
+++ b/kubejs/client_scripts/common/tooltips.js
@@ -40,4 +40,10 @@ ItemEvents.tooltip(event => {
         text.add(4, Text.of('   §bAbsolute Stabilization'));
     });
 
+    //Custom Colossal Chest Tooltips
+    const colossalTypes = [`wood`, `copper`, `iron`, `silver`, `gold`, `diamond`, `obsidian`];
+    colossalTypes.forEach(type => {
+        event.add(`colossalchests:colossal_chest_${type}`, Text.translate(`item.colossalchests.colossal_chest_${type}.tooltip`));
+    });
+
 });

--- a/kubejs/client_scripts/common/tooltips.js
+++ b/kubejs/client_scripts/common/tooltips.js
@@ -43,7 +43,6 @@ ItemEvents.tooltip(event => {
     //Custom Colossal Chest Tooltips
     const colossalTypes = [`wood`, `copper`, `iron`, `silver`, `gold`, `diamond`, `obsidian`];
     colossalTypes.forEach(type => {
-        event.add(`colossalchests:colossal_chest_${type}`, Text.translate(`item.colossalchests.colossal_chest_${type}.tooltip`));
+        event.add(`colossalchests:colossal_chest_${type}`, Text.translate(`item.colossalchests.colossal_chest.tooltip`));
     });
-
 });


### PR DESCRIPTION
Added a max colossal chest size of 5x5x5 for corruption safety and added tooltips to the chest cores.
In ref to this message: https://discord.com/channels/1177211394039484477/1273197593827999755/1463792847336636488