### PR TITLE
Element adjustments

### DIFF
--- a/kubejs/startup_scripts/common/elements_materials/elements/abydos.js
+++ b/kubejs/startup_scripts/common/elements_materials/elements/abydos.js
@@ -3,8 +3,8 @@ GTCEuStartupEvents.registry('gtceu:element', event => {
     
     const elem = global.elementFunction(event);
 
-    elem('zapolgium', 141, 217, 'Zg');
-    elem('akreyrium', -1, -1, 'Ak');
+    elem('zapolgium', 138, 217, 'Zg');
+    elem('akreyrium', 164, 280, 'Ak');
     elem('dysprosium', 66, 98, 'Dy');
 
 });

--- a/kubejs/startup_scripts/common/elements_materials/elements/end.js
+++ b/kubejs/startup_scripts/common/elements_materials/elements/end.js
@@ -3,9 +3,9 @@ GTCEuStartupEvents.registry('gtceu:element', event => {
     
     const elem = global.elementFunction(event);
 
-    elem('xeproda', 136, 265, 'Xp');
-    elem('rhexis', 137, 298, 'Rx');
-    elem('chalyblux', 138, 312, 'Cx');
+    elem('xeproda', 146, 245, 'Xp');
+    elem('rhexis', 147, 247, 'Rx');
+    elem('chalyblux', 148, 249, 'Cx');
     elem('voidic', -1, -1, '∅');
     elem('dragon', -1, -1, '🜍');
 

--- a/kubejs/startup_scripts/common/elements_materials/elements/gate.js
+++ b/kubejs/startup_scripts/common/elements_materials/elements/gate.js
@@ -3,7 +3,7 @@ GTCEuStartupEvents.registry('gtceu:element', event => {
     
     const elem = global.elementFunction(event);
 
-    elem('purified_naquadah', 174, 350, 'Nq-');
-    elem('echo_r', -1, -1, 'Ec');
+    elem('purified_naquadah', 154, 250, 'Nq-');
+    elem('echo_r', 152, 252, 'Ec');
 
 });

--- a/kubejs/startup_scripts/common/elements_materials/elements/modifications.js
+++ b/kubejs/startup_scripts/common/elements_materials/elements/modifications.js
@@ -1,0 +1,18 @@
+
+GTCEuStartupEvents.registry('gtceu:element', event => {
+
+    const setCounts = (name, protons, neutrons) => {
+        let elem = GTElements.get(name);
+        elem.protons(protons);
+        elem.neutrons(neutrons);
+    }
+
+    [
+        { name: 'Tritanium', protons: 125, neutrons: 198 },
+        { name: 'Trinium', protons: 150, neutrons: 251 },
+        { name: 'Naquadah', protons: 154, neutrons: 252 },
+        { name: 'Naquadria', protons: 155, neutrons: 255 },
+        { name: 'NaquadahEnriched', protons: 156, neutrons: 256 }
+    ].forEach(e => setCounts(e.name, e.protons, e.neutrons));
+
+});

--- a/kubejs/startup_scripts/common/elements_materials/elements/modifications.js
+++ b/kubejs/startup_scripts/common/elements_materials/elements/modifications.js
@@ -12,7 +12,8 @@ GTCEuStartupEvents.registry('gtceu:element', event => {
         { name: 'Trinium', protons: 150, neutrons: 251 },
         { name: 'Naquadah', protons: 154, neutrons: 252 },
         { name: 'Naquadria', protons: 155, neutrons: 255 },
-        { name: 'NaquadahEnriched', protons: 156, neutrons: 256 }
+        { name: 'NaquadahEnriched', protons: 156, neutrons: 256 },
+        { name: 'Duranium', protons: 123, neutrons: 112 }
     ].forEach(e => setCounts(e.name, e.protons, e.neutrons));
 
 });

--- a/kubejs/startup_scripts/common/elements_materials/elements/nether.js
+++ b/kubejs/startup_scripts/common/elements_materials/elements/nether.js
@@ -3,13 +3,13 @@ GTCEuStartupEvents.registry('gtceu:element', event => {
     
     const elem = global.elementFunction(event);
 
-    elem('mythril', 132, 193, 'My');
-    elem('adamantine', 131, 182, 'Ad');
-    elem('estalt', 133, 199, 'El');
-    elem('enriched_estalt', 133, 212, 'El+');
-    elem('calamatium', 134, 211, 'Ct');
-    elem('isovol', 135, 221, 'Is');
-    elem('ancient_netherite', 124, 295, 'Nr+');
+    elem('mythril', 133, 193, 'My');
+    elem('adamantine', 132, 182, 'Ad');
+    elem('estalt', 134, 199, 'El');
+    elem('enriched_estalt', 134, 212, 'El+');
+    elem('calamatium', 135, 211, 'Ct');
+    elem('isovol', 136, 221, 'Is');
+    elem('ancient_netherite', 124, 195, 'Nr+');
     elem('aurourium', -1, -1, '*A*')
 
 });

--- a/kubejs/startup_scripts/common/elements_materials/elements/netherite.js
+++ b/kubejs/startup_scripts/common/elements_materials/elements/netherite.js
@@ -3,7 +3,7 @@ GTCEuStartupEvents.registry('gtceu:element', event => {
     
     const elem = global.elementFunction(event);
 
-    elem('debris', -1, -1, '?');
-    elem('pure_netherite', 124, 345, '*Nr*');
+    elem('debris', 122, 138, '?');
+    elem('pure_netherite', 124, 187, '*Nr*');
 
 });

--- a/kubejs/startup_scripts/common/elements_materials/elements/netherite.js
+++ b/kubejs/startup_scripts/common/elements_materials/elements/netherite.js
@@ -4,6 +4,7 @@ GTCEuStartupEvents.registry('gtceu:element', event => {
     const elem = global.elementFunction(event);
 
     elem('debris', 122, 138, '?');
+    elem('netherite', 124, 191, 'Nr');
     elem('pure_netherite', 124, 187, '*Nr*');
 
 });

--- a/kubejs/startup_scripts/common/elements_materials/material/materials.js
+++ b/kubejs/startup_scripts/common/elements_materials/material/materials.js
@@ -328,6 +328,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
     matmod('iron', foil);
     matmod('wrought_iron', frame);
     matmod('red_alloy', spring);
+    matmod('netherite', no_decomp);
 
     // Blast Properties of periodic table metals
     const blast = global.blastProperty;
@@ -344,6 +345,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 
     // Fluid Pipes
     GTMaterials.NaquadahEnriched.setProperty(PropertyKey.FLUID_PIPE, new FluidPipeProperties(8000, 500, true, true, true, false));
+    GTMaterials.Netherite.setComponents('4x netherite', '4x gold');
 
     // Materials from elements
     const compIngot = (name, elements, color, icon, blasting, flags) => {


### PR DESCRIPTION
Based on https://discord.com/channels/1177211394039484477/1273197593827999755/1452204862405345280

Changes (element -> protons, neutrons):
- Debris -> 122, 136
- Duranium -> 123, 112
- Estalt -> 134, 199
- Enriched Estalt -> 134, 212
- Calamatium -> 135, 211
- Isovol -> 135, 357
- Zapolgium -> 138, 217
- Xeproda -> 146, 245
- Rhexis -> 147, 247
- Chalyblux -> 148, 249
- Trinium -> 150, 251
- Aurorium -> 151, 251
- Echo -> 152, 252
- Naquadah -> 154, 252
- Enriched Naquadah -> 154, 254
- Naquadria -> 154, 248
- Purified Naquadah -> 154, 250
- Akreyrium -> 164, 280

This makes the elements more in line with the islands of stability for super heavy elements. Also this means recipe duration decreases for autogenerated recipes with these elements.

Also gave netherite a proper composition. Although we added a new element for netherite, actual netherite remains as an alloy, but now displays a proper chemical formula.