### PR TITLE
Changed Efficency Rates of ARC Kits to Promote Mixing and Matching Kits

### DIFF
--- a/config/ftbquests/quests/chapters/power.snbt
+++ b/config/ftbquests/quests/chapters/power.snbt
@@ -566,7 +566,7 @@
 					id: "kubejs:lv_arc_kit"
 					tag: {
 						AugmentData: {
-							DynamoEnergy: 0.9f
+							DynamoEnergy: 0.95f
 							DynamoPower: 0.5f
 							Type: "Dynamo"
 						}
@@ -591,7 +591,7 @@
 					id: "kubejs:mv_arc_kit"
 					tag: {
 						AugmentData: {
-							DynamoEnergy: 0.8f
+							DynamoEnergy: 0.9f
 							DynamoPower: 1.0f
 							Type: "Dynamo"
 						}
@@ -616,7 +616,7 @@
 					id: "kubejs:hv_arc_kit"
 					tag: {
 						AugmentData: {
-							DynamoEnergy: 0.7f
+							DynamoEnergy: 0.85f
 							DynamoPower: 2.0f
 							Type: "Dynamo"
 						}
@@ -641,7 +641,7 @@
 					id: "kubejs:ev_arc_kit"
 					tag: {
 						AugmentData: {
-							DynamoEnergy: 0.6f
+							DynamoEnergy: 0.8f
 							DynamoPower: 3.0f
 							Type: "Dynamo"
 						}

--- a/kubejs/server_scripts/common/additions/progression/power/thermal_augments.js
+++ b/kubejs/server_scripts/common/additions/progression/power/thermal_augments.js
@@ -19,7 +19,7 @@ ServerEvents.recipes(event => {
     // ARC augments
     event.recipes.gtceu.assembler(id('lv_arc_augment'))
         .itemInputs('2x gtceu:bronze_plate', '2x gtceu:silver_gear', 'thermal_extra:soul_infused_glass')
-        .itemOutputs(Item.of('kubejs:lv_arc_kit', '{AugmentData:{Type: Dynamo, DynamoEnergy:0.9f, DynamoPower:0.5f}}'))
+        .itemOutputs(Item.of('kubejs:lv_arc_kit', '{AugmentData:{Type: Dynamo, DynamoEnergy:.95f, DynamoPower:0.5f}}'))
         .duration(600)
         .EUt(28);
 
@@ -76,9 +76,9 @@ ServerEvents.recipes(event => {
     
     // ARC's and MCI's
     [
-        {tier: 'mv', last_tier: 'lv', gear: 'gold', glass: 'signalum', DynEA: 0.8, DynP: 1, DynEM: 1.30, energy: 'mv'},
-        {tier: 'hv', last_tier: 'mv', gear: 'electrum', glass: 'lumium', DynEA: 0.7, DynP: 2, DynEM: 1.45, energy: 'hv'},
-        {tier: 'ev', last_tier: 'hv', gear: 'blue_alloy', glass: 'enderium', DynEA: 0.6, DynP: 3, DynEM: 1.6, energy: 'ev'}
+        {tier: 'mv', last_tier: 'lv', gear: 'gold', glass: 'signalum', DynEA: 0.9, DynP: 1, DynEM: 1.30, energy: 'mv'},
+        {tier: 'hv', last_tier: 'mv', gear: 'electrum', glass: 'lumium', DynEA: 0.85, DynP: 2, DynEM: 1.45, energy: 'hv'},
+        {tier: 'ev', last_tier: 'hv', gear: 'blue_alloy', glass: 'enderium', DynEA: 0.8, DynP: 3, DynEM: 1.6, energy: 'ev'}
     ].forEach(tier=> {
         event.recipes.gtceu.assembler(id(`arc_augment_${tier.tier}`))
             .itemInputs(`kubejs:${tier.last_tier}_arc_kit`, `2x gtceu:${tier.gear}_gear`, `thermal:${tier.glass}_glass`)

--- a/packmode/abydos/config/ftbquests/quests/chapters/power.snbt
+++ b/packmode/abydos/config/ftbquests/quests/chapters/power.snbt
@@ -3,7 +3,7 @@
 	default_quest_shape: "square"
 	filename: "power"
 	group: "28726466D987C725"
-	icon: "kubejs:mv_upgrade_kit"
+	icon: "kubejs:mv_upgraade_kit"
 	id: "10A89CD14C4DAF63"
 	order_index: 0
 	quest_links: [
@@ -1673,7 +1673,7 @@
 				id: "43336F4858ECFE9C"
 				item: {
 					Count: 1
-					id: "kubejs:mv_upgrade_kit"
+					id: "kubejs:mv_upgraade_kit"
 					tag: {
 						AugmentData: {
 							BaseMod: 12.0f
@@ -1707,7 +1707,7 @@
 				id: "0FFFC4310BE7E52C"
 				item: {
 					Count: 1
-					id: "kubejs:lv_upgrade_kit"
+					id: "kubejs:lv_upgraade_kit"
 					tag: {
 						AugmentData: {
 							BaseMod: 6.0f
@@ -1731,7 +1731,7 @@
 				id: "41E49D5E9F070FF8"
 				item: {
 					Count: 1
-					id: "kubejs:hv_upgrade_kit"
+					id: "kubejs:hv_upgraade_kit"
 					tag: {
 						AugmentData: {
 							BaseMod: 24.0f
@@ -1755,7 +1755,7 @@
 				id: "5E662ABFA472940F"
 				item: {
 					Count: 1
-					id: "kubejs:ev_upgrade_kit"
+					id: "kubejs:ev_upgraade_kit"
 					tag: {
 						AugmentData: {
 							BaseMod: 48.0f

--- a/packmode/default/config/ftbquests/quests/chapters/power.snbt
+++ b/packmode/default/config/ftbquests/quests/chapters/power.snbt
@@ -1673,7 +1673,7 @@
 				id: "43336F4858ECFE9C"
 				item: {
 					Count: 1
-					id: "kubejs:mv_upgrade_kit"
+					id: "kubejs:mv_upgraade_kit"
 					tag: {
 						AugmentData: {
 							BaseMod: 12.0f
@@ -1707,7 +1707,7 @@
 				id: "0FFFC4310BE7E52C"
 				item: {
 					Count: 1
-					id: "kubejs:lv_upgrade_kit"
+					id: "kubejs:lv_upgraade_kit"
 					tag: {
 						AugmentData: {
 							BaseMod: 6.0f
@@ -1731,7 +1731,7 @@
 				id: "41E49D5E9F070FF8"
 				item: {
 					Count: 1
-					id: "kubejs:hv_upgrade_kit"
+					id: "kubejs:hv_upgraade_kit"
 					tag: {
 						AugmentData: {
 							BaseMod: 24.0f
@@ -1755,7 +1755,7 @@
 				id: "5E662ABFA472940F"
 				item: {
 					Count: 1
-					id: "kubejs:ev_upgrade_kit"
+					id: "kubejs:ev_upgraade_kit"
 					tag: {
 						AugmentData: {
 							BaseMod: 48.0f


### PR DESCRIPTION
Current Rates Pre Buff
<img width="368" height="136" alt="image" src="https://github.com/user-attachments/assets/a8d21f42-02e7-497c-8ee7-921bc2fe9c2f" />

Post Buff Rates

<img width="752" height="165" alt="image" src="https://github.com/user-attachments/assets/3d719909-4324-41fd-829e-a3c190d66285" />

Making it worthwhile to mix and match different augments at different tiers.