### PR TITLE
Update gt config

### DIFF
--- a/config/gtceu.yaml
+++ b/config/gtceu.yaml
@@ -506,10 +506,10 @@ client:
 
   tankItemFluidPreview:
     # Set true to render the including fluid icons to GT Drums
-    drum: false
+    drum: true
 
     # Set true to render the including fluid icons to Super (Quantum) Tanks
-    quantumTank: false
+    quantumTank: true
 
 # Config options for Tools and Armor
 tools:

--- a/config/gtceu.yaml
+++ b/config/gtceu.yaml
@@ -26,7 +26,7 @@ recipes:
   # Default: false
   hardWoodRecipes: false
   # Packmode Sensitivity
-  
+
   # Recipes for Buckets, Cauldrons, Hoppers, and Iron Bars require Iron Plates, Rods, and more.
   # Default: true
   hardIronRecipes: true
@@ -35,13 +35,13 @@ recipes:
   # Default: false
   hardRedstoneRecipes: false
   # Packmode Sensitivity
-  
+
   # Whether to make Vanilla Tools and Armor recipes harder.
   # Excludes Flint and Steel, and Buckets.
   # Default: false
   hardToolArmorRecipes: false
   # Packmode Sensitivity
-  
+
   # Whether to make miscellaneous recipes harder.
   # Default: false
   hardMiscRecipes: false
@@ -53,7 +53,7 @@ recipes:
   # Default: true
   nerfPaperCrafting: false
   # Packmode Sensitivity
-  
+
   # Recipes for items like Iron Doors, Trapdoors, Anvil require Iron Plates, Rods, and more.
   # Default: false
   hardAdvancedIronRecipes: false
@@ -86,6 +86,11 @@ recipes:
   # Default: false
   harderCircuitRecipes: false
 
+  # Whether ULV components should have harder recipes using bronze
+  # Requires ULV components to be enabled
+  # Default: true
+  ulvComponentsHarderRecipes: true
+
   # Whether to nerf machine controller recipes.
   # Default: false
   hardMultiRecipes: false
@@ -94,7 +99,35 @@ recipes:
   # Default: true
   enchantedTools: true
   # Packmode Sensitivity
-  
+
+  # Whether to enable macerator decomposition recycling
+  # Default: true
+  enableMaceratorRecycling: true
+
+  # Percentage yield of macerator decomposition recycling outputs, 1.0 means 100%
+  # Default: 1.0f
+  maceratorRecyclingYield: 1.0
+
+  # Whether to enable arc furnace decomposition recycling
+  # Default: true
+  enableArcRecycling: true
+
+  # Percentage yield of arc furnace decomposition recycling outputs, 1.0 means 100%
+  # Default: 1.0f
+  arcRecyclingYield: 1.0
+
+  # Whether to enable extractor decomposition recycling
+  # Default: true
+  enableExtractorRecycling: true
+
+  # Percentage yield of extractor decomposition recycling outputs, 1.0 means 100%
+  # Default: 1.0f
+  extractorRecyclingYield: 1.0
+
+  # Chanced input and outputs use the recipe overclock instead of the speed overclock
+  # Default: true
+  chanceUseRecipeOC: true
+
 worldgen:
   # Rubber Tree spawn chance (decimal % per chunk)
   # Default: 0.5
@@ -159,14 +192,8 @@ worldgen:
     oreIndicatorChunkCacheSize: 2048
 
 machines:
-  # Whether insufficient energy supply should reset Machine recipe progress to zero.
-  # If true, progress will reset.
-  # If false, progress will decrease to zero with 2x speed
-  # Default: false
-  recipeProgressLowEnergy: false
-
   # Whether to require a Wrench, Wirecutter, or other GregTech tools to break machines, casings, wires, and more.
-  # Default: false
+  # Default: true
   requireGTToolsForBlocks: false
 
   # Whether machines explode in rainy weather or when placed next to certain terrain, such as fire or lava
@@ -194,6 +221,10 @@ machines:
   # Default: true
   machineSounds: true
 
+  # Duration in ticks that batching will try to reach.
+  # Default: 100
+  batchDuration: 100
+
   # Whether Steam Multiblocks should use Steel instead of Bronze.
   # Default: false
   steelSteamMultiblocks: false
@@ -207,6 +238,10 @@ machines:
   # Default: false
   cleanMultiblocks: false
 
+  # Whether the miner should attempt to replace the block mined with a cobbled version of the ore
+  # Default: true
+  replaceWithCobbleVersion: true
+
   # Block to replace mined ores with in the miner and multiblock miner.
   # Default: minecraft:cobblestone
   replaceMinedBlocksWith: minecraft:cobblestone
@@ -219,11 +254,16 @@ machines:
   # Default: true
   enableMaintenance: true
 
+  # How often to check for maintenance, rolling a 1/6000 chance every X ticks (before secondary effects like Configurable Maintenance Hatch).
+  # In default settings, this equates to a 5% chance every hour of a machine running.
+  # Default: 1000 (ticks)
+  maintenanceCheckRate: 1000
+
   # Whether to enable World Accelerators, which accelerate ticks for surrounding Tile Entities, Crops, etc.
   # Default: true
   enableWorldAccelerators: false
   # Packmode Sensitivity
-  
+
   # List of TileEntities that the World Accelerator should not accelerate.
   # GregTech TileEntities are always blocked.
   # Entries must be in a fully qualified format. For example: appeng.tile.networking.TileController
@@ -265,7 +305,7 @@ machines:
   # Default: 50
   ldItemPipeMinDistance: 50
 
-  # Minimum distance betweeb Long Distance Fluid Pipe Endpoints
+  # Minimum distance between Long Distance Fluid Pipe Endpoints
   # Default: 50
   ldFluidPipeMinDistance: 50
 
@@ -288,6 +328,10 @@ machines:
   # Default: false
   highTierContent: true
 
+  # Whether ULV components should be enabled
+  # Default: false
+  ulvComponentsEnabled: true
+
   # Whether the Assembly Line should require the item inputs to be in order.
   # Default: true
   orderedAssemblyLineItems: true
@@ -297,10 +341,29 @@ machines:
   # Default: false
   orderedAssemblyLineFluids: false
   # Packmode Sensitivity
-  
+
   # Default maximum parallel of steam multiblocks
   # Default: 8
   steamMultiParallelAmount: 8
+
+  # Whether the Large Chemical Reactor should have coil benefits. WARNING: Setting this to true will remove perfect overclock from the LCR!
+  # Default: true
+  lcrCoilBenefits: true
+
+  # Whether to add a parallel version of the LCR.
+  # Default: true
+  parallelLCR: true
+
+  # Whether the Drums can input fluids from the output side (bottom).
+  allowDrumsInputFluidsFromOutputSide: false
+
+  # Whether the Super/Quantum Tanks should act the same as fluid cells for filling/emptying fluid slots.
+  # Default: false
+  superTankFluidCellBehavior: false
+
+  # Whether multiblocks stall (pause) on power fail.
+  # Default: false
+  multiblocksStallOnPowerFail: false
 
   # Small Steam Boiler Options
   smallBoilers:
@@ -343,8 +406,8 @@ machines:
     bronzeBoilerHeatSpeed: 1
 
     # The max temperature of the Large Steel Boiler.
-    # Default: 1800
-    steelBoilerMaxTemperature: 1800
+    # Default: 1600
+    steelBoilerMaxTemperature: 1600
 
     # The heat speed of the Large Steel Boiler.
     # Default: 1
@@ -371,6 +434,11 @@ client:
   # Default: true
   machinesEmissiveTextures: true
 
+  # Whether most machines will have block entity renderers, mainly used for rendering certain covers. (Restart required)
+  # Disable if experiencing performance issues.
+  # Default: true
+  machinesHaveBERsByDefault: true
+
   # Whether or not sounds should be played when using tools outside of crafting.
   # Default: true
   toolUseSounds: true
@@ -385,8 +453,8 @@ client:
   defaultPaintingColor: #FFFFFF
 
   # The default color to overlay onto Machine (and other) UIs.
-  # 16777215 (#FFFFFF) is no coloring (like GTCE) (default).
-  # 13819135 (#D2DCFF in decimal) is the classic blue from GT5.
+  # #FFFFFF is no coloring (like GTCE) (default).
+  # #D2DCFF is the classic blue from GT5.
   defaultUIColor: #FFFFFF
 
   # Use VBO cache for multiblock preview.
@@ -423,6 +491,25 @@ client:
     # Render fluids in multiblocks that support them?
     # Default: true
     renderFluids: true
+
+    # Render growing plants in multiblocks that support them?
+    # Default: true
+    renderGrowingPlants: true
+
+    # Whether or not to color tiered machine highlights in the tier color
+    # Default: true
+    coloredTieredMachineOutline: true
+
+    # Whether or not to color wire/cable highlights based on voltage tier
+    # Default: true
+    coloredWireOutline: true
+
+  tankItemFluidPreview:
+    # Set true to render the including fluid icons to GT Drums
+    drum: false
+
+    # Set true to render the including fluid icons to Super (Quantum) Tanks
+    quantumTank: false
 
 # Config options for Tools and Armor
 tools:
@@ -471,7 +558,7 @@ tools:
   voltageTierQuarkTech: 5
 
   # Advanced QuarkTech Suit Chestplate Voltage Tier.
-  # Default: 5 (LuV)
+  # Default: 6 (LuV)
   voltageTierAdvQuarkTech: 6
 
   # Electric Impeller Jetpack Voltage Tier.
@@ -494,7 +581,7 @@ gameplay:
   universalHazards: false
 
   # Whether environmental hazards like pollution or radiation are active
-  # Default: true
+  # Default: false
   environmentalHazards: false
 
   # How much environmental hazards decay per chunk, per tick.
@@ -518,14 +605,14 @@ compat:
     # Only affects converters.
     # Default: 4 FE == 1 EU
     feToEuRatio: 4
-  # Packmode Sensitivity
-  
+    # Packmode Sensitivity
+
     # GTEU to Forge Energy ratio for converting EU to FE.
     # Affects native conversion and Converters.
     # Default: 4 FE == 1 EU
     euToFeRatio: 4
-  # Packmode Sensitivity
-  
+    # Packmode Sensitivity
+
   # Config options regarding GTCEu compatibility with AE2
   ae2:
     # The interval between ME Hatch/Bus interact ME network.
@@ -534,7 +621,7 @@ compat:
     updateIntervals: 40
 
     # The energy consumption of ME Hatch/Bus.
-    # Default: 1.0AE/t
+    # Default: 4.0AE/t
     meHatchEnergyUsage: 1.0
 
   # Config options regarding GTCEu compatibility with minimap mods
@@ -547,7 +634,7 @@ compat:
       # Journey Map integration enabled
       journeyMapIntegration: true
 
-      # Xaerox's map integration enabled
+      # Xaero's map integration enabled
       xaerosMapIntegration: true
 
     # The radius, in blocks, that picking up a surface rock will search for veins in.
@@ -587,7 +674,7 @@ compat:
     buttonAnchor: BOTTOM_LEFT
 
     # Which direction the buttons will go
-    # Default: "HORIZONTAL"
+    # Default: "VERTICAL"
     # Allowed values:
     # - VERTICAL
     # - HORIZONTAL
@@ -601,10 +688,6 @@ compat:
     # Default: 0
     yOffset: 0
 
-    # Whether to put buttons on a separate toolbar on the right instead of the map type toolbar in JourneyMap.
-    # Default: true
-    rightToolbar: true
-
   # Whether to hide facades of all blocks in JEI and creative search menu.
   # Default: true
   hideFacadesInRecipeViewer: true
@@ -617,7 +700,7 @@ compat:
   # Default: false
   hideOreProcessingDiagrams: false
 
-  # Whether Gregtech should remove smelting recipes from the vanilla furnace for ingots requiring the Electric Blast Furnace.
+  # Whether GregTech should remove smelting recipes from the vanilla furnace for ingots requiring the Electric Blast Furnace.
   # Default: true
   removeSmeltingForEBFMetals: true
 
@@ -625,8 +708,12 @@ compat:
   # Default: false
   showDimensionTier: false
 
+  # Whether Create compatibility will be available.
+  # Default: true
+  createCompat: true
+
 dev:
-  # Debug general events? (will print recipe conficts etc. to server's debug.log)
+  # Debug general events? (will print recipe conflicts etc. to server's debug.log)
   # Default: false
   debug: false
 

--- a/kubejs/server_scripts/hardmode/progression/pre_lv/ulv.js
+++ b/kubejs/server_scripts/hardmode/progression/pre_lv/ulv.js
@@ -162,31 +162,35 @@ ServerEvents.recipes(event => {
         event.recipes.createDeploying(pist, [pist, 'gtceu:potin_plate'])
     ]).transitionalItem(pist).loops(2).id('start:sequenced_assembly/ulv_electric_piston');
 
+    // remove default ulv component recipes and add new ones that require the new components and machines
+    event.remove({output: /gtceu:ulv_(electric_(motor|piston|pump)|conveyor_module|robot_arm)/});
+    // removing recylcing recipes
+    event.remove({id: /gtceu:(arc_furnace\/arc_|macerator\/macerate_)ulv_(electric_(piston|pump)|conveyor_module|robot_arm)/}); // ulv electric motor does not have recycling recipes
     const UlvComponent = (output,inputs,fluid) => {
       if(output == 'electric_motor')
       event.recipes.gtceu.assembler(id(`ulv_${output}`))
         .itemInputs(inputs[0],inputs[1],inputs[2],inputs[3])
-        .itemOutputs(`kubejs:ulv_${output}`)
+        .itemOutputs(`gtceu:ulv_${output}`)
         .duration(100)
         .EUt(6);
     if(output == 'electric_piston')
       event.recipes.gtceu.assembler(id(`ulv_${output}`))
         .itemInputs(inputs[0],inputs[1],inputs[2],inputs[3],inputs[4])
-        .itemOutputs(`kubejs:ulv_${output}`)
+        .itemOutputs(`gtceu:ulv_${output}`)
         .duration(100)
         .circuit(1)
         .EUt(6);
     if(output == 'robot_arm')
       event.recipes.gtceu.assembler(id(`ulv_${output}`))
         .itemInputs(inputs[0],inputs[1],inputs[2],inputs[3],inputs[4])
-        .itemOutputs(`kubejs:ulv_${output}`)
+        .itemOutputs(`gtceu:ulv_${output}`)
         .duration(100)
         .circuit(1)
         .EUt(6);
     if(output == 'electric_pump')
       event.recipes.gtceu.assembler(id(`ulv_${output}`))
         .itemInputs(inputs[0],inputs[1],inputs[2],inputs[3],inputs[4],inputs[5])
-        .itemOutputs(`kubejs:ulv_${output}`)
+        .itemOutputs(`gtceu:ulv_${output}`)
         .duration(100)
         .EUt(6);
     if(output == 'emitter')
@@ -200,7 +204,7 @@ ServerEvents.recipes(event => {
       event.recipes.gtceu.assembler(id(`${output}_ulv`))
         .itemInputs(inputs[0],inputs[1])
         .inputFluids(fluid)
-        .itemOutputs(`kubejs:ulv_${output}`)
+        .itemOutputs(`gtceu:ulv_${output}`)
         .duration(100)
         .circuit(1)
         .EUt(6);

--- a/packmode/abydos/config/gtceu.yaml
+++ b/packmode/abydos/config/gtceu.yaml
@@ -506,10 +506,10 @@ client:
 
   tankItemFluidPreview:
     # Set true to render the including fluid icons to GT Drums
-    drum: false
+    drum: true
 
     # Set true to render the including fluid icons to Super (Quantum) Tanks
-    quantumTank: false
+    quantumTank: true
 
 # Config options for Tools and Armor
 tools:

--- a/packmode/abydos/config/gtceu.yaml
+++ b/packmode/abydos/config/gtceu.yaml
@@ -86,6 +86,11 @@ recipes:
   # Default: false
   harderCircuitRecipes: false
 
+  # Whether ULV components should have harder recipes using bronze
+  # Requires ULV components to be enabled
+  # Default: true
+  ulvComponentsHarderRecipes: true
+
   # Whether to nerf machine controller recipes.
   # Default: false
   hardMultiRecipes: false
@@ -94,6 +99,34 @@ recipes:
   # Default: true
   enchantedTools: true
   # Packmode Sensitivity
+
+  # Whether to enable macerator decomposition recycling
+  # Default: true
+  enableMaceratorRecycling: true
+
+  # Percentage yield of macerator decomposition recycling outputs, 1.0 means 100%
+  # Default: 1.0f
+  maceratorRecyclingYield: 1.0
+
+  # Whether to enable arc furnace decomposition recycling
+  # Default: true
+  enableArcRecycling: true
+
+  # Percentage yield of arc furnace decomposition recycling outputs, 1.0 means 100%
+  # Default: 1.0f
+  arcRecyclingYield: 1.0
+
+  # Whether to enable extractor decomposition recycling
+  # Default: true
+  enableExtractorRecycling: true
+
+  # Percentage yield of extractor decomposition recycling outputs, 1.0 means 100%
+  # Default: 1.0f
+  extractorRecyclingYield: 1.0
+
+  # Chanced input and outputs use the recipe overclock instead of the speed overclock
+  # Default: true
+  chanceUseRecipeOC: true
 
 worldgen:
   # Rubber Tree spawn chance (decimal % per chunk)
@@ -159,14 +192,8 @@ worldgen:
     oreIndicatorChunkCacheSize: 2048
 
 machines:
-  # Whether insufficient energy supply should reset Machine recipe progress to zero.
-  # If true, progress will reset.
-  # If false, progress will decrease to zero with 2x speed
-  # Default: false
-  recipeProgressLowEnergy: false
-
   # Whether to require a Wrench, Wirecutter, or other GregTech tools to break machines, casings, wires, and more.
-  # Default: false
+  # Default: true
   requireGTToolsForBlocks: false
 
   # Whether machines explode in rainy weather or when placed next to certain terrain, such as fire or lava
@@ -194,6 +221,10 @@ machines:
   # Default: true
   machineSounds: true
 
+  # Duration in ticks that batching will try to reach.
+  # Default: 100
+  batchDuration: 100
+
   # Whether Steam Multiblocks should use Steel instead of Bronze.
   # Default: false
   steelSteamMultiblocks: false
@@ -207,6 +238,10 @@ machines:
   # Default: false
   cleanMultiblocks: false
 
+  # Whether the miner should attempt to replace the block mined with a cobbled version of the ore
+  # Default: true
+  replaceWithCobbleVersion: true
+
   # Block to replace mined ores with in the miner and multiblock miner.
   # Default: minecraft:cobblestone
   replaceMinedBlocksWith: minecraft:cobblestone
@@ -219,10 +254,15 @@ machines:
   # Default: true
   enableMaintenance: true
 
+  # How often to check for maintenance, rolling a 1/6000 chance every X ticks (before secondary effects like Configurable Maintenance Hatch).
+  # In default settings, this equates to a 5% chance every hour of a machine running.
+  # Default: 1000 (ticks)
+  maintenanceCheckRate: 1000
+
   # Whether to enable World Accelerators, which accelerate ticks for surrounding Tile Entities, Crops, etc.
   # Default: true
   enableWorldAccelerators: false
-  # Packmode Sensitivity, Turned to Purely False for Zeta, too many exploits
+  # Packmode Sensitivity
 
   # List of TileEntities that the World Accelerator should not accelerate.
   # GregTech TileEntities are always blocked.
@@ -265,7 +305,7 @@ machines:
   # Default: 50
   ldItemPipeMinDistance: 50
 
-  # Minimum distance betweeb Long Distance Fluid Pipe Endpoints
+  # Minimum distance between Long Distance Fluid Pipe Endpoints
   # Default: 50
   ldFluidPipeMinDistance: 50
 
@@ -288,6 +328,10 @@ machines:
   # Default: false
   highTierContent: true
 
+  # Whether ULV components should be enabled
+  # Default: false
+  ulvComponentsEnabled: true
+
   # Whether the Assembly Line should require the item inputs to be in order.
   # Default: true
   orderedAssemblyLineItems: true
@@ -301,6 +345,25 @@ machines:
   # Default maximum parallel of steam multiblocks
   # Default: 8
   steamMultiParallelAmount: 8
+
+  # Whether the Large Chemical Reactor should have coil benefits. WARNING: Setting this to true will remove perfect overclock from the LCR!
+  # Default: true
+  lcrCoilBenefits: true
+
+  # Whether to add a parallel version of the LCR.
+  # Default: true
+  parallelLCR: true
+
+  # Whether the Drums can input fluids from the output side (bottom).
+  allowDrumsInputFluidsFromOutputSide: false
+
+  # Whether the Super/Quantum Tanks should act the same as fluid cells for filling/emptying fluid slots.
+  # Default: false
+  superTankFluidCellBehavior: false
+
+  # Whether multiblocks stall (pause) on power fail.
+  # Default: false
+  multiblocksStallOnPowerFail: false
 
   # Small Steam Boiler Options
   smallBoilers:
@@ -343,8 +406,8 @@ machines:
     bronzeBoilerHeatSpeed: 1
 
     # The max temperature of the Large Steel Boiler.
-    # Default: 1800
-    steelBoilerMaxTemperature: 1800
+    # Default: 1600
+    steelBoilerMaxTemperature: 1600
 
     # The heat speed of the Large Steel Boiler.
     # Default: 1
@@ -371,6 +434,11 @@ client:
   # Default: true
   machinesEmissiveTextures: true
 
+  # Whether most machines will have block entity renderers, mainly used for rendering certain covers. (Restart required)
+  # Disable if experiencing performance issues.
+  # Default: true
+  machinesHaveBERsByDefault: true
+
   # Whether or not sounds should be played when using tools outside of crafting.
   # Default: true
   toolUseSounds: true
@@ -385,8 +453,8 @@ client:
   defaultPaintingColor: #FFFFFF
 
   # The default color to overlay onto Machine (and other) UIs.
-  # 16777215 (#FFFFFF) is no coloring (like GTCE) (default).
-  # 13819135 (#D2DCFF in decimal) is the classic blue from GT5.
+  # #FFFFFF is no coloring (like GTCE) (default).
+  # #D2DCFF is the classic blue from GT5.
   defaultUIColor: #FFFFFF
 
   # Use VBO cache for multiblock preview.
@@ -423,6 +491,25 @@ client:
     # Render fluids in multiblocks that support them?
     # Default: true
     renderFluids: true
+
+    # Render growing plants in multiblocks that support them?
+    # Default: true
+    renderGrowingPlants: true
+
+    # Whether or not to color tiered machine highlights in the tier color
+    # Default: true
+    coloredTieredMachineOutline: true
+
+    # Whether or not to color wire/cable highlights based on voltage tier
+    # Default: true
+    coloredWireOutline: true
+
+  tankItemFluidPreview:
+    # Set true to render the including fluid icons to GT Drums
+    drum: false
+
+    # Set true to render the including fluid icons to Super (Quantum) Tanks
+    quantumTank: false
 
 # Config options for Tools and Armor
 tools:
@@ -471,7 +558,7 @@ tools:
   voltageTierQuarkTech: 5
 
   # Advanced QuarkTech Suit Chestplate Voltage Tier.
-  # Default: 5 (LuV)
+  # Default: 6 (LuV)
   voltageTierAdvQuarkTech: 6
 
   # Electric Impeller Jetpack Voltage Tier.
@@ -494,7 +581,7 @@ gameplay:
   universalHazards: false
 
   # Whether environmental hazards like pollution or radiation are active
-  # Default: true
+  # Default: false
   environmentalHazards: false
 
   # How much environmental hazards decay per chunk, per tick.
@@ -534,7 +621,7 @@ compat:
     updateIntervals: 40
 
     # The energy consumption of ME Hatch/Bus.
-    # Default: 1.0AE/t
+    # Default: 4.0AE/t
     meHatchEnergyUsage: 1.0
 
   # Config options regarding GTCEu compatibility with minimap mods
@@ -547,7 +634,7 @@ compat:
       # Journey Map integration enabled
       journeyMapIntegration: true
 
-      # Xaerox's map integration enabled
+      # Xaero's map integration enabled
       xaerosMapIntegration: true
 
     # The radius, in blocks, that picking up a surface rock will search for veins in.
@@ -587,7 +674,7 @@ compat:
     buttonAnchor: BOTTOM_LEFT
 
     # Which direction the buttons will go
-    # Default: "HORIZONTAL"
+    # Default: "VERTICAL"
     # Allowed values:
     # - VERTICAL
     # - HORIZONTAL
@@ -601,10 +688,6 @@ compat:
     # Default: 0
     yOffset: 0
 
-    # Whether to put buttons on a separate toolbar on the right instead of the map type toolbar in JourneyMap.
-    # Default: true
-    rightToolbar: true
-
   # Whether to hide facades of all blocks in JEI and creative search menu.
   # Default: true
   hideFacadesInRecipeViewer: true
@@ -617,7 +700,7 @@ compat:
   # Default: false
   hideOreProcessingDiagrams: false
 
-  # Whether Gregtech should remove smelting recipes from the vanilla furnace for ingots requiring the Electric Blast Furnace.
+  # Whether GregTech should remove smelting recipes from the vanilla furnace for ingots requiring the Electric Blast Furnace.
   # Default: true
   removeSmeltingForEBFMetals: true
 
@@ -625,8 +708,12 @@ compat:
   # Default: false
   showDimensionTier: false
 
+  # Whether Create compatibility will be available.
+  # Default: true
+  createCompat: true
+
 dev:
-  # Debug general events? (will print recipe conficts etc. to server's debug.log)
+  # Debug general events? (will print recipe conflicts etc. to server's debug.log)
   # Default: false
   debug: false
 

--- a/packmode/default/config/gtceu.yaml
+++ b/packmode/default/config/gtceu.yaml
@@ -506,10 +506,10 @@ client:
 
   tankItemFluidPreview:
     # Set true to render the including fluid icons to GT Drums
-    drum: false
+    drum: true
 
     # Set true to render the including fluid icons to Super (Quantum) Tanks
-    quantumTank: false
+    quantumTank: true
 
 # Config options for Tools and Armor
 tools:

--- a/packmode/default/config/gtceu.yaml
+++ b/packmode/default/config/gtceu.yaml
@@ -86,6 +86,11 @@ recipes:
   # Default: false
   harderCircuitRecipes: false
 
+  # Whether ULV components should have harder recipes using bronze
+  # Requires ULV components to be enabled
+  # Default: true
+  ulvComponentsHarderRecipes: true
+
   # Whether to nerf machine controller recipes.
   # Default: false
   hardMultiRecipes: false
@@ -94,6 +99,34 @@ recipes:
   # Default: true
   enchantedTools: true
   # Packmode Sensitivity
+
+  # Whether to enable macerator decomposition recycling
+  # Default: true
+  enableMaceratorRecycling: true
+
+  # Percentage yield of macerator decomposition recycling outputs, 1.0 means 100%
+  # Default: 1.0f
+  maceratorRecyclingYield: 1.0
+
+  # Whether to enable arc furnace decomposition recycling
+  # Default: true
+  enableArcRecycling: true
+
+  # Percentage yield of arc furnace decomposition recycling outputs, 1.0 means 100%
+  # Default: 1.0f
+  arcRecyclingYield: 1.0
+
+  # Whether to enable extractor decomposition recycling
+  # Default: true
+  enableExtractorRecycling: true
+
+  # Percentage yield of extractor decomposition recycling outputs, 1.0 means 100%
+  # Default: 1.0f
+  extractorRecyclingYield: 1.0
+
+  # Chanced input and outputs use the recipe overclock instead of the speed overclock
+  # Default: true
+  chanceUseRecipeOC: true
 
 worldgen:
   # Rubber Tree spawn chance (decimal % per chunk)
@@ -159,14 +192,8 @@ worldgen:
     oreIndicatorChunkCacheSize: 2048
 
 machines:
-  # Whether insufficient energy supply should reset Machine recipe progress to zero.
-  # If true, progress will reset.
-  # If false, progress will decrease to zero with 2x speed
-  # Default: false
-  recipeProgressLowEnergy: false
-
   # Whether to require a Wrench, Wirecutter, or other GregTech tools to break machines, casings, wires, and more.
-  # Default: false
+  # Default: true
   requireGTToolsForBlocks: false
 
   # Whether machines explode in rainy weather or when placed next to certain terrain, such as fire or lava
@@ -194,6 +221,10 @@ machines:
   # Default: true
   machineSounds: true
 
+  # Duration in ticks that batching will try to reach.
+  # Default: 100
+  batchDuration: 100
+
   # Whether Steam Multiblocks should use Steel instead of Bronze.
   # Default: false
   steelSteamMultiblocks: false
@@ -207,6 +238,10 @@ machines:
   # Default: false
   cleanMultiblocks: false
 
+  # Whether the miner should attempt to replace the block mined with a cobbled version of the ore
+  # Default: true
+  replaceWithCobbleVersion: true
+
   # Block to replace mined ores with in the miner and multiblock miner.
   # Default: minecraft:cobblestone
   replaceMinedBlocksWith: minecraft:cobblestone
@@ -219,10 +254,15 @@ machines:
   # Default: true
   enableMaintenance: true
 
+  # How often to check for maintenance, rolling a 1/6000 chance every X ticks (before secondary effects like Configurable Maintenance Hatch).
+  # In default settings, this equates to a 5% chance every hour of a machine running.
+  # Default: 1000 (ticks)
+  maintenanceCheckRate: 1000
+
   # Whether to enable World Accelerators, which accelerate ticks for surrounding Tile Entities, Crops, etc.
   # Default: true
   enableWorldAccelerators: false
-  # Packmode Sensitivity, Turned to Purely False for Zeta, too many exploits
+  # Packmode Sensitivity
 
   # List of TileEntities that the World Accelerator should not accelerate.
   # GregTech TileEntities are always blocked.
@@ -265,7 +305,7 @@ machines:
   # Default: 50
   ldItemPipeMinDistance: 50
 
-  # Minimum distance betweeb Long Distance Fluid Pipe Endpoints
+  # Minimum distance between Long Distance Fluid Pipe Endpoints
   # Default: 50
   ldFluidPipeMinDistance: 50
 
@@ -288,6 +328,10 @@ machines:
   # Default: false
   highTierContent: true
 
+  # Whether ULV components should be enabled
+  # Default: false
+  ulvComponentsEnabled: true
+
   # Whether the Assembly Line should require the item inputs to be in order.
   # Default: true
   orderedAssemblyLineItems: true
@@ -301,6 +345,25 @@ machines:
   # Default maximum parallel of steam multiblocks
   # Default: 8
   steamMultiParallelAmount: 8
+
+  # Whether the Large Chemical Reactor should have coil benefits. WARNING: Setting this to true will remove perfect overclock from the LCR!
+  # Default: true
+  lcrCoilBenefits: true
+
+  # Whether to add a parallel version of the LCR.
+  # Default: true
+  parallelLCR: true
+
+  # Whether the Drums can input fluids from the output side (bottom).
+  allowDrumsInputFluidsFromOutputSide: false
+
+  # Whether the Super/Quantum Tanks should act the same as fluid cells for filling/emptying fluid slots.
+  # Default: false
+  superTankFluidCellBehavior: false
+
+  # Whether multiblocks stall (pause) on power fail.
+  # Default: false
+  multiblocksStallOnPowerFail: false
 
   # Small Steam Boiler Options
   smallBoilers:
@@ -343,8 +406,8 @@ machines:
     bronzeBoilerHeatSpeed: 1
 
     # The max temperature of the Large Steel Boiler.
-    # Default: 1800
-    steelBoilerMaxTemperature: 1800
+    # Default: 1600
+    steelBoilerMaxTemperature: 1600
 
     # The heat speed of the Large Steel Boiler.
     # Default: 1
@@ -371,6 +434,11 @@ client:
   # Default: true
   machinesEmissiveTextures: true
 
+  # Whether most machines will have block entity renderers, mainly used for rendering certain covers. (Restart required)
+  # Disable if experiencing performance issues.
+  # Default: true
+  machinesHaveBERsByDefault: true
+
   # Whether or not sounds should be played when using tools outside of crafting.
   # Default: true
   toolUseSounds: true
@@ -385,8 +453,8 @@ client:
   defaultPaintingColor: #FFFFFF
 
   # The default color to overlay onto Machine (and other) UIs.
-  # 16777215 (#FFFFFF) is no coloring (like GTCE) (default).
-  # 13819135 (#D2DCFF in decimal) is the classic blue from GT5.
+  # #FFFFFF is no coloring (like GTCE) (default).
+  # #D2DCFF is the classic blue from GT5.
   defaultUIColor: #FFFFFF
 
   # Use VBO cache for multiblock preview.
@@ -423,6 +491,25 @@ client:
     # Render fluids in multiblocks that support them?
     # Default: true
     renderFluids: true
+
+    # Render growing plants in multiblocks that support them?
+    # Default: true
+    renderGrowingPlants: true
+
+    # Whether or not to color tiered machine highlights in the tier color
+    # Default: true
+    coloredTieredMachineOutline: true
+
+    # Whether or not to color wire/cable highlights based on voltage tier
+    # Default: true
+    coloredWireOutline: true
+
+  tankItemFluidPreview:
+    # Set true to render the including fluid icons to GT Drums
+    drum: false
+
+    # Set true to render the including fluid icons to Super (Quantum) Tanks
+    quantumTank: false
 
 # Config options for Tools and Armor
 tools:
@@ -471,7 +558,7 @@ tools:
   voltageTierQuarkTech: 5
 
   # Advanced QuarkTech Suit Chestplate Voltage Tier.
-  # Default: 5 (LuV)
+  # Default: 6 (LuV)
   voltageTierAdvQuarkTech: 6
 
   # Electric Impeller Jetpack Voltage Tier.
@@ -494,7 +581,7 @@ gameplay:
   universalHazards: false
 
   # Whether environmental hazards like pollution or radiation are active
-  # Default: true
+  # Default: false
   environmentalHazards: false
 
   # How much environmental hazards decay per chunk, per tick.
@@ -534,7 +621,7 @@ compat:
     updateIntervals: 40
 
     # The energy consumption of ME Hatch/Bus.
-    # Default: 1.0AE/t
+    # Default: 4.0AE/t
     meHatchEnergyUsage: 1.0
 
   # Config options regarding GTCEu compatibility with minimap mods
@@ -547,7 +634,7 @@ compat:
       # Journey Map integration enabled
       journeyMapIntegration: true
 
-      # Xaerox's map integration enabled
+      # Xaero's map integration enabled
       xaerosMapIntegration: true
 
     # The radius, in blocks, that picking up a surface rock will search for veins in.
@@ -587,7 +674,7 @@ compat:
     buttonAnchor: BOTTOM_LEFT
 
     # Which direction the buttons will go
-    # Default: "HORIZONTAL"
+    # Default: "VERTICAL"
     # Allowed values:
     # - VERTICAL
     # - HORIZONTAL
@@ -601,10 +688,6 @@ compat:
     # Default: 0
     yOffset: 0
 
-    # Whether to put buttons on a separate toolbar on the right instead of the map type toolbar in JourneyMap.
-    # Default: true
-    rightToolbar: true
-
   # Whether to hide facades of all blocks in JEI and creative search menu.
   # Default: true
   hideFacadesInRecipeViewer: true
@@ -617,7 +700,7 @@ compat:
   # Default: false
   hideOreProcessingDiagrams: false
 
-  # Whether Gregtech should remove smelting recipes from the vanilla furnace for ingots requiring the Electric Blast Furnace.
+  # Whether GregTech should remove smelting recipes from the vanilla furnace for ingots requiring the Electric Blast Furnace.
   # Default: true
   removeSmeltingForEBFMetals: true
 
@@ -625,8 +708,12 @@ compat:
   # Default: false
   showDimensionTier: false
 
+  # Whether Create compatibility will be available.
+  # Default: true
+  createCompat: true
+
 dev:
-  # Debug general events? (will print recipe conficts etc. to server's debug.log)
+  # Debug general events? (will print recipe conflicts etc. to server's debug.log)
   # Default: false
   debug: false
 

--- a/packmode/hard/config/gtceu.yaml
+++ b/packmode/hard/config/gtceu.yaml
@@ -506,10 +506,10 @@ client:
 
   tankItemFluidPreview:
     # Set true to render the including fluid icons to GT Drums
-    drum: false
+    drum: true
 
     # Set true to render the including fluid icons to Super (Quantum) Tanks
-    quantumTank: false
+    quantumTank: true
 
 # Config options for Tools and Armor
 tools:

--- a/packmode/hard/config/gtceu.yaml
+++ b/packmode/hard/config/gtceu.yaml
@@ -86,6 +86,11 @@ recipes:
   # Default: false
   harderCircuitRecipes: false
 
+  # Whether ULV components should have harder recipes using bronze
+  # Requires ULV components to be enabled
+  # Default: true
+  ulvComponentsHarderRecipes: true
+
   # Whether to nerf machine controller recipes.
   # Default: false
   hardMultiRecipes: false
@@ -94,6 +99,34 @@ recipes:
   # Default: true
   enchantedTools: false
   # Packmode Sensitivity
+
+  # Whether to enable macerator decomposition recycling
+  # Default: true
+  enableMaceratorRecycling: true
+
+  # Percentage yield of macerator decomposition recycling outputs, 1.0 means 100%
+  # Default: 1.0f
+  maceratorRecyclingYield: 1.0
+
+  # Whether to enable arc furnace decomposition recycling
+  # Default: true
+  enableArcRecycling: true
+
+  # Percentage yield of arc furnace decomposition recycling outputs, 1.0 means 100%
+  # Default: 1.0f
+  arcRecyclingYield: 1.0
+
+  # Whether to enable extractor decomposition recycling
+  # Default: true
+  enableExtractorRecycling: true
+
+  # Percentage yield of extractor decomposition recycling outputs, 1.0 means 100%
+  # Default: 1.0f
+  extractorRecyclingYield: 1.0
+
+  # Chanced input and outputs use the recipe overclock instead of the speed overclock
+  # Default: true
+  chanceUseRecipeOC: true
 
 worldgen:
   # Rubber Tree spawn chance (decimal % per chunk)
@@ -159,14 +192,8 @@ worldgen:
     oreIndicatorChunkCacheSize: 2048
 
 machines:
-  # Whether insufficient energy supply should reset Machine recipe progress to zero.
-  # If true, progress will reset.
-  # If false, progress will decrease to zero with 2x speed
-  # Default: false
-  recipeProgressLowEnergy: false
-
   # Whether to require a Wrench, Wirecutter, or other GregTech tools to break machines, casings, wires, and more.
-  # Default: false
+  # Default: true
   requireGTToolsForBlocks: false
 
   # Whether machines explode in rainy weather or when placed next to certain terrain, such as fire or lava
@@ -194,6 +221,10 @@ machines:
   # Default: true
   machineSounds: true
 
+  # Duration in ticks that batching will try to reach.
+  # Default: 100
+  batchDuration: 100
+
   # Whether Steam Multiblocks should use Steel instead of Bronze.
   # Default: false
   steelSteamMultiblocks: false
@@ -207,6 +238,10 @@ machines:
   # Default: false
   cleanMultiblocks: false
 
+  # Whether the miner should attempt to replace the block mined with a cobbled version of the ore
+  # Default: true
+  replaceWithCobbleVersion: true
+
   # Block to replace mined ores with in the miner and multiblock miner.
   # Default: minecraft:cobblestone
   replaceMinedBlocksWith: minecraft:cobblestone
@@ -218,6 +253,11 @@ machines:
   # Whether to enable the Maintenance Hatch, required for Multiblocks.
   # Default: true
   enableMaintenance: true
+
+  # How often to check for maintenance, rolling a 1/6000 chance every X ticks (before secondary effects like Configurable Maintenance Hatch).
+  # In default settings, this equates to a 5% chance every hour of a machine running.
+  # Default: 1000 (ticks)
+  maintenanceCheckRate: 1000
 
   # Whether to enable World Accelerators, which accelerate ticks for surrounding Tile Entities, Crops, etc.
   # Default: true
@@ -265,7 +305,7 @@ machines:
   # Default: 50
   ldItemPipeMinDistance: 50
 
-  # Minimum distance betweeb Long Distance Fluid Pipe Endpoints
+  # Minimum distance between Long Distance Fluid Pipe Endpoints
   # Default: 50
   ldFluidPipeMinDistance: 50
 
@@ -288,6 +328,10 @@ machines:
   # Default: false
   highTierContent: true
 
+  # Whether ULV components should be enabled
+  # Default: false
+  ulvComponentsEnabled: true
+
   # Whether the Assembly Line should require the item inputs to be in order.
   # Default: true
   orderedAssemblyLineItems: true
@@ -301,6 +345,25 @@ machines:
   # Default maximum parallel of steam multiblocks
   # Default: 8
   steamMultiParallelAmount: 8
+
+  # Whether the Large Chemical Reactor should have coil benefits. WARNING: Setting this to true will remove perfect overclock from the LCR!
+  # Default: true
+  lcrCoilBenefits: true
+
+  # Whether to add a parallel version of the LCR.
+  # Default: true
+  parallelLCR: true
+
+  # Whether the Drums can input fluids from the output side (bottom).
+  allowDrumsInputFluidsFromOutputSide: false
+
+  # Whether the Super/Quantum Tanks should act the same as fluid cells for filling/emptying fluid slots.
+  # Default: false
+  superTankFluidCellBehavior: false
+
+  # Whether multiblocks stall (pause) on power fail.
+  # Default: false
+  multiblocksStallOnPowerFail: false
 
   # Small Steam Boiler Options
   smallBoilers:
@@ -343,8 +406,8 @@ machines:
     bronzeBoilerHeatSpeed: 1
 
     # The max temperature of the Large Steel Boiler.
-    # Default: 1800
-    steelBoilerMaxTemperature: 1800
+    # Default: 1600
+    steelBoilerMaxTemperature: 1600
 
     # The heat speed of the Large Steel Boiler.
     # Default: 1
@@ -371,6 +434,11 @@ client:
   # Default: true
   machinesEmissiveTextures: true
 
+  # Whether most machines will have block entity renderers, mainly used for rendering certain covers. (Restart required)
+  # Disable if experiencing performance issues.
+  # Default: true
+  machinesHaveBERsByDefault: true
+
   # Whether or not sounds should be played when using tools outside of crafting.
   # Default: true
   toolUseSounds: true
@@ -385,8 +453,8 @@ client:
   defaultPaintingColor: #FFFFFF
 
   # The default color to overlay onto Machine (and other) UIs.
-  # 16777215 (#FFFFFF) is no coloring (like GTCE) (default).
-  # 13819135 (#D2DCFF in decimal) is the classic blue from GT5.
+  # #FFFFFF is no coloring (like GTCE) (default).
+  # #D2DCFF is the classic blue from GT5.
   defaultUIColor: #FFFFFF
 
   # Use VBO cache for multiblock preview.
@@ -423,6 +491,25 @@ client:
     # Render fluids in multiblocks that support them?
     # Default: true
     renderFluids: true
+
+    # Render growing plants in multiblocks that support them?
+    # Default: true
+    renderGrowingPlants: true
+
+    # Whether or not to color tiered machine highlights in the tier color
+    # Default: true
+    coloredTieredMachineOutline: true
+
+    # Whether or not to color wire/cable highlights based on voltage tier
+    # Default: true
+    coloredWireOutline: true
+
+  tankItemFluidPreview:
+    # Set true to render the including fluid icons to GT Drums
+    drum: false
+
+    # Set true to render the including fluid icons to Super (Quantum) Tanks
+    quantumTank: false
 
 # Config options for Tools and Armor
 tools:
@@ -471,7 +558,7 @@ tools:
   voltageTierQuarkTech: 5
 
   # Advanced QuarkTech Suit Chestplate Voltage Tier.
-  # Default: 5 (LuV)
+  # Default: 6 (LuV)
   voltageTierAdvQuarkTech: 6
 
   # Electric Impeller Jetpack Voltage Tier.
@@ -494,7 +581,7 @@ gameplay:
   universalHazards: false
 
   # Whether environmental hazards like pollution or radiation are active
-  # Default: true
+  # Default: false
   environmentalHazards: false
 
   # How much environmental hazards decay per chunk, per tick.
@@ -534,7 +621,7 @@ compat:
     updateIntervals: 40
 
     # The energy consumption of ME Hatch/Bus.
-    # Default: 1.0AE/t
+    # Default: 4.0AE/t
     meHatchEnergyUsage: 1.0
 
   # Config options regarding GTCEu compatibility with minimap mods
@@ -547,7 +634,7 @@ compat:
       # Journey Map integration enabled
       journeyMapIntegration: true
 
-      # Xaerox's map integration enabled
+      # Xaero's map integration enabled
       xaerosMapIntegration: true
 
     # The radius, in blocks, that picking up a surface rock will search for veins in.
@@ -587,7 +674,7 @@ compat:
     buttonAnchor: BOTTOM_LEFT
 
     # Which direction the buttons will go
-    # Default: "HORIZONTAL"
+    # Default: "VERTICAL"
     # Allowed values:
     # - VERTICAL
     # - HORIZONTAL
@@ -601,10 +688,6 @@ compat:
     # Default: 0
     yOffset: 0
 
-    # Whether to put buttons on a separate toolbar on the right instead of the map type toolbar in JourneyMap.
-    # Default: true
-    rightToolbar: true
-
   # Whether to hide facades of all blocks in JEI and creative search menu.
   # Default: true
   hideFacadesInRecipeViewer: true
@@ -617,7 +700,7 @@ compat:
   # Default: false
   hideOreProcessingDiagrams: false
 
-  # Whether Gregtech should remove smelting recipes from the vanilla furnace for ingots requiring the Electric Blast Furnace.
+  # Whether GregTech should remove smelting recipes from the vanilla furnace for ingots requiring the Electric Blast Furnace.
   # Default: true
   removeSmeltingForEBFMetals: true
 
@@ -625,8 +708,12 @@ compat:
   # Default: false
   showDimensionTier: false
 
+  # Whether Create compatibility will be available.
+  # Default: true
+  createCompat: true
+
 dev:
-  # Debug general events? (will print recipe conficts etc. to server's debug.log)
+  # Debug general events? (will print recipe conflicts etc. to server's debug.log)
   # Default: false
   debug: false
 


### PR DESCRIPTION
Updates the GT config file for all packmodes while preserving the existing config values.

Hardmode now uses the actual ULV components.

Considerations before merging:
1. Should ULV component recipes use copper (easy recipes) or bronze (harder recipes)? (I'm leaning towards bronze)
```yml
# Whether ULV components should have harder recipes using bronze
  # Requires ULV components to be enabled
  # Default: true
  ulvComponentsHarderRecipes: true
```
2. Should we enable rendering of fluids in the super/quantum tanks and drums? (leaning yes for drums, no for tanks)
```yml
tankItemFluidPreview:
    # Set true to render the including fluid icons to GT Drums
    drum: false

    # Set true to render the including fluid icons to Super (Quantum) Tanks
    quantumTank: false
 ```
 
<img width="141" height="105" alt="image" src="https://github.com/user-attachments/assets/e07ff502-b6e4-4b84-8c91-2c36cd54e8a5" />
