### PR TITLE
Conditional kubejs recipe loading

### DIFF
--- a/kubejs/server_scripts/common/additions/progression/lines/nether_lines/misc_materials.js
+++ b/kubejs/server_scripts/common/additions/progression/lines/nether_lines/misc_materials.js
@@ -35,8 +35,10 @@ ServerEvents.recipes(event => {
         .duration(100 * size)
         .EUt(GTValues.VA[GTValues.LuV]);
     };
-    WarpedMaceration('#chipped:warped_roots', 1);
-    WarpedMaceration('#chipped:warped_fungus', 1);
+    global.with_chipped(() => {
+        WarpedMaceration('#chipped:warped_roots', 1);
+        WarpedMaceration('#chipped:warped_fungus', 1);
+    })
     WarpedMaceration('minecraft:warped_wart_block', 9);
     
     //Ancient Netherite

--- a/kubejs/server_scripts/common/modifications/create_hypertubes.js
+++ b/kubejs/server_scripts/common/modifications/create_hypertubes.js
@@ -1,4 +1,5 @@
 //requires: create_hypertube
+global.with_create_hypertube(() => {
 ServerEvents.recipes(event => {
     const id = global.id;
 
@@ -20,4 +21,5 @@ ServerEvents.recipes(event => {
     assembler(['create:smart_chute', 'create_hypertube:hypertube', 'create:cogwheel'], 'create_hypertube:hypertube_entrance', 100, 30, 'hypertube_entrance');
     assembler(['create_hypertube:hypertube_entrance', 'gtceu:lv_voltage_coil', 'create:cogwheel'], 'create_hypertube:hypertube_accelerator', 100, 30, 'hypertube_accelerato');
 
+});
 });

--- a/kubejs/server_scripts/common/modifications/flux_networks.js
+++ b/kubejs/server_scripts/common/modifications/flux_networks.js
@@ -1,3 +1,4 @@
+global.with_fluxnetworks(() => {
 ServerEvents.recipes(event => {
     const id = global.id;
 
@@ -9,4 +10,5 @@ ServerEvents.recipes(event => {
     .EUt(1024)
     .circuit(1);
 
+});
 });

--- a/kubejs/server_scripts/common/modifications/functional_storage.js
+++ b/kubejs/server_scripts/common/modifications/functional_storage.js
@@ -1,3 +1,4 @@
+global.with_functionalstorage(() => {
 ServerEvents.recipes(event => {
     const id = global.id;
 
@@ -85,6 +86,7 @@ ServerEvents.recipes(event => {
         C: '#gtceu:circuits/lv'
     }).id('start:shaped/ender_drawer');
 
+    global.with_framedblocks(() => {
     [
         '1',
         '2',
@@ -94,6 +96,7 @@ ServerEvents.recipes(event => {
         event.shapeless(`1x functionalstorage:framed_${size}`, [`1x #functionalstorage:drawer_size_${size}`, 'framedblocks:framed_hammer']).id(`start:shapeless/framed_drawer_${size}`);
     })
     event.shapeless('1x functionalstorage:framed_storage_controller', ['functionalstorage:storage_controller', 'framedblocks:framed_hammer']);
+    });
 
     event.shaped('1x functionalstorage:redstone_upgrade', [
         ' R ',
@@ -108,4 +111,5 @@ ServerEvents.recipes(event => {
     event.shapeless('functionalstorage:pusher_upgrade', [Item.of('functionalstorage:puller_upgrade'), '#forge:tools/screwdrivers']).id('start:shapeless/pusher_flip');
     event.shapeless('functionalstorage:puller_upgrade', [Item.of('functionalstorage:pusher_upgrade'), '#forge:tools/screwdrivers']).id('start:shapeless/puller_flip');
 
+});
 });

--- a/kubejs/server_scripts/common/modifications/general.js
+++ b/kubejs/server_scripts/common/modifications/general.js
@@ -78,6 +78,7 @@ ServerEvents.recipes(event => {
     }).id('start:shaped/advanced_wireless_terminal');
 
     // Effortless Building Upgrade Accessibility
+    global.with_effortlessbuilding(() => {
     const reachUpgrade = (type,mat,dye,core) => {
         event.remove({output: `effortlessbuilding:reach_upgrade${type}`});
         event.shaped(Item.of(`effortlessbuilding:reach_upgrade${type}`), [
@@ -94,6 +95,7 @@ ServerEvents.recipes(event => {
     reachUpgrade('1','minecraft:slime_ball','minecraft:lime_dye',`minecraft:ender_pearl`);
     reachUpgrade('2','minecraft:glowstone_dust','minecraft:orange_dye',`effortlessbuilding:reach_upgrade1`);
     reachUpgrade('3','minecraft:amethyst_shard','minecraft:purple_dye',`effortlessbuilding:reach_upgrade2`);
+    });
 
     // Bingus
     event.shaped('bingus:floppa_orb', [

--- a/kubejs/server_scripts/common/modifications/project_red.js
+++ b/kubejs/server_scripts/common/modifications/project_red.js
@@ -1,4 +1,5 @@
 
+global.with_projectred(() => {
 ServerEvents.recipes(event => {
 
     const core = (id) => `projectred_core:${id}`;
@@ -24,4 +25,5 @@ ServerEvents.tags('item', event => {
     event.remove('forge:dusts/electrotine', 'projectred_core:electrotine_dust');
     event.add('c:logic_gates', /projectred_integration:.*_gate/);
 
+});
 });

--- a/kubejs/server_scripts/common/modifications/travel_anchors.js
+++ b/kubejs/server_scripts/common/modifications/travel_anchors.js
@@ -1,3 +1,4 @@
+global.with_travelanchors(() => {
 ServerEvents.recipes(event => {
     const id = global.id;
 
@@ -23,4 +24,5 @@ ServerEvents.recipes(event => {
         R: 'gtceu:iron_rod'
     }).id('start:shaped/travel_staff');
 
+});
 });

--- a/kubejs/server_scripts/common/modifications/xycraft.js
+++ b/kubejs/server_scripts/common/modifications/xycraft.js
@@ -1,3 +1,4 @@
+global.with_xycraft_world(() => {
 ServerEvents.recipes(event => {
     const id = global.id;
 
@@ -44,4 +45,5 @@ ServerEvents.recipes(event => {
         D: 'minecraft:deepslate'
     }).id('start:shaped/kivi');
 
+});
 });

--- a/kubejs/server_scripts/common/systems/agriculture/tree_greenhouse.js
+++ b/kubejs/server_scripts/common/systems/agriculture/tree_greenhouse.js
@@ -1,7 +1,7 @@
 ServerEvents.recipes(event => {
     const id = global.id;
 
-    [
+    let woodTypes = [
         { name: 'oak', sapling: 'oak_sapling', namespace: 'minecraft'},
         { name: 'dark_oak', sapling: 'dark_oak_sapling', namespace: 'minecraft'},
         { name: 'birch', sapling: 'birch_sapling', namespace: 'minecraft'},
@@ -9,9 +9,12 @@ ServerEvents.recipes(event => {
         { name: 'acacia', sapling: 'acacia_sapling', namespace: 'minecraft'},
         { name: 'jungle', sapling: 'jungle_sapling', namespace: 'minecraft'},
         { name: 'cherry', sapling: 'cherry_sapling', namespace: 'minecraft'},
-        { name: 'mangrove', sapling: 'mangrove_propagule', namespace: 'minecraft'},
-        { name: 'twisted', sapling: 'twisted_sapling', namespace: 'architects_palette'},
-    ].forEach(type => {
+        { name: 'mangrove', sapling: 'mangrove_propagule', namespace: 'minecraft'}
+    ];
+    global.with_architects_palette(() => {
+        woodTypes.push({ name: 'twisted', sapling: 'twisted_sapling', namespace: 'architects_palette'});
+    })
+    woodTypes.forEach(type => {
         event.recipes.gtceu.tree_greenhouse(id(`${type.name}_growing`))
             .notConsumable(`${type.namespace}:${type.sapling}`)
             .itemOutputs(`16x ${type.namespace}:${type.name}_log`)

--- a/kubejs/server_scripts/default/additions/progression/early_game/sieving.js
+++ b/kubejs/server_scripts/default/additions/progression/early_game/sieving.js
@@ -197,13 +197,6 @@ global.not_hardmode(() => {
             .add('minecraft:sea_pickle', 0.05)
             .add('kelp', 0.15)
             .add('minecraft:seagrass', 0.15)
-            // Waterlogged Dust Sieving
-            .input(csi.dust)
-            .add('xycraft_world:xychorium_gem_blue', 0.75)
-            .add('xycraft_world:xychorium_gem_red', 0.75)
-            .add('xycraft_world:xychorium_gem_green', 0.75)
-            .add('xycraft_world:xychorium_gem_light', 0.75)
-            .add('xycraft_world:xychorium_gem_dark', 0.75)
             // Gravel Sieving
             .input(csi.gravel)
             .waterlogged(false)
@@ -258,7 +251,21 @@ global.not_hardmode(() => {
             .add('exnihilosequentia:dripstone_pebble', 0.05)
             .add('exnihilosequentia:granite_pebble', 0.05)
             .add('exnihilosequentia:stone_pebble', 0.05)
-            .add('exnihilosequentia:tuff_pebble', 0.05)
+            .add('exnihilosequentia:tuff_pebble', 0.05);
+
+        global.with_xycraft_world(() => {
+            // Waterlogged Dust Sieving
+        SievingRecipeHandler
+            .input(csi.dust)
+            .add('xycraft_world:xychorium_gem_blue', 0.75)
+            .add('xycraft_world:xychorium_gem_red', 0.75)
+            .add('xycraft_world:xychorium_gem_green', 0.75)
+            .add('xycraft_world:xychorium_gem_light', 0.75)
+            .add('xycraft_world:xychorium_gem_dark', 0.75);
+
+        })
+
+        SievingRecipeHandler
             .build(event);
 
         //Dirts

--- a/kubejs/server_scripts/default/modifications/create/new_age.js
+++ b/kubejs/server_scripts/default/modifications/create/new_age.js
@@ -1,5 +1,6 @@
 //requires: create_new_age
-    global.not_hardmode(() => {
+global.not_hardmode(() => {
+    global.with_create_new_age(() => {
         
     ServerEvents.recipes(event => {
         const id = global.id;
@@ -80,5 +81,6 @@
             E: 'gtceu:energium_dust'
         }).id('start:shaped/neodymium_magnet');
 
+    });
     });
 });

--- a/kubejs/server_scripts/default/modifications/create/vintage.js
+++ b/kubejs/server_scripts/default/modifications/create/vintage.js
@@ -1,5 +1,6 @@
 //requires: vintage
 global.not_hardmode(() => {
+    global.with_vintage(() => {
     ServerEvents.recipes(event => {
         const id = global.id;
 
@@ -128,5 +129,6 @@ global.not_hardmode(() => {
             create.splashing([`gtceu:${mainOre}_dust`, Item.of(`gtceu:${terOre}_dust`).withChance(0.02)], `gtceu:pure_${mainOre}_dust`).id(id(`splashing/pure_${mainOre}`));
         });
 
+    });
     });
 });

--- a/kubejs/server_scripts/default/modifications/item_collectors.js
+++ b/kubejs/server_scripts/default/modifications/item_collectors.js
@@ -1,4 +1,5 @@
 global.not_hardmode(() => {
+    global.with_itemcollectors(() => {
 
     ServerEvents.recipes(event => {
     const id = global.id;
@@ -22,5 +23,6 @@ global.not_hardmode(() => {
             B: 'gtceu:black_bronze_plate'
         }).id('start:shaped/advanced_collectors');
 
+    });
     });
 });

--- a/kubejs/server_scripts/default/modifications/pipez.js
+++ b/kubejs/server_scripts/default/modifications/pipez.js
@@ -1,4 +1,5 @@
 global.not_hardmode(() => {
+    global.with_pipez(() => {
 
     ServerEvents.recipes(event => {
         const id = global.id;
@@ -121,5 +122,6 @@ global.not_hardmode(() => {
             ).id(`start:shapeless/pipez_${tier}_upgrade_reset`);
         });
 
+    });
     });
 });

--- a/kubejs/server_scripts/utils/helpers/recipe_helpers.js
+++ b/kubejs/server_scripts/utils/helpers/recipe_helpers.js
@@ -316,3 +316,34 @@ ServerEvents.recipes(event => {
   }
   
 });
+
+
+const modRequirements = {
+    pipez: 'pipez',
+    itemcollectors: 'itemcollectors',
+    vintage: 'vintage',
+    create_new_age: 'create_new_age',
+    travelanchors: 'travelanchors',
+    fluxnetworks: 'fluxnetworks',
+    architects_palette: 'architects_palette',
+    xycraft_world: 'xycraft_world',
+    chipped: 'chipped',
+    framedblocks: 'framedblocks',
+    functionalstorage: 'functionalstorage',
+    effortlessbuilding: 'effortlessbuilding',
+    projectred: ['projectred_core', 'projectred_transmission', 'projectred_integration']
+};
+
+// Auto-generate all the wrapper functions
+Object.entries(modRequirements).forEach(([name, mod]) => {
+    const mods = Array.isArray(mod) ? mod : [mod];
+    /**
+     * @param {function} fun - Function to execute if current mod is loaded'.
+     */
+    global[`with_${name}`] = (fun) => {
+        if (mods.every(m => Platform.isLoaded(m))) {
+            fun();
+        }
+    };
+});
+


### PR DESCRIPTION
## Description
Recipes that depend on small mods now only load when those mods are present. Previously, missing mod dependencies would cause errors. Methods are auto generated from a lookup table, so really easily expandable.

## QOL
This makes updating the modpack significantly easier — no more manually removing recipes or troubleshooting errors when a small decor mod is removed.