### PR TITLE
Conditional recipe loading

### DIFF
--- a/kubejs/server_scripts/common/additions/progression/lines/nether_lines/misc_materials.js
+++ b/kubejs/server_scripts/common/additions/progression/lines/nether_lines/misc_materials.js
@@ -35,8 +35,13 @@ ServerEvents.recipes(event => {
         .duration(100 * size)
         .EUt(GTValues.VA[GTValues.LuV]);
     };
-    WarpedMaceration('#chipped:warped_roots', 1);
-    WarpedMaceration('#chipped:warped_fungus', 1);
+    global.with_chipped(() => {
+        WarpedMaceration('#chipped:warped_roots', 1);
+        WarpedMaceration('#chipped:warped_fungus', 1);
+    }, () => {
+        WarpedMaceration('minecraft:warped_roots', 1);
+        WarpedMaceration('minecraft:warped_fungus', 1);
+    })
     WarpedMaceration('minecraft:warped_wart_block', 9);
     
     //Ancient Netherite

--- a/kubejs/server_scripts/common/modifications/flux_networks.js
+++ b/kubejs/server_scripts/common/modifications/flux_networks.js
@@ -1,3 +1,4 @@
+//requires: fluxnetworks
 ServerEvents.recipes(event => {
     const id = global.id;
 

--- a/kubejs/server_scripts/common/modifications/functional_storage.js
+++ b/kubejs/server_scripts/common/modifications/functional_storage.js
@@ -1,3 +1,4 @@
+//requires: functionalstorage
 ServerEvents.recipes(event => {
     const id = global.id;
 
@@ -85,15 +86,27 @@ ServerEvents.recipes(event => {
         C: '#gtceu:circuits/lv'
     }).id('start:shaped/ender_drawer');
 
-    [
-        '1',
-        '2',
-        '4'
-    ].forEach(size => {
-        event.remove({ output: `functionalstorage:framed_${size}` });
-        event.shapeless(`1x functionalstorage:framed_${size}`, [`1x #functionalstorage:drawer_size_${size}`, 'framedblocks:framed_hammer']).id(`start:shapeless/framed_drawer_${size}`);
-    })
-    event.shapeless('1x functionalstorage:framed_storage_controller', ['functionalstorage:storage_controller', 'framedblocks:framed_hammer']);
+    global.with_framedblocks(() => {
+        [
+            '1',
+            '2',
+            '4'
+        ].forEach(size => {
+            event.remove({ output: `functionalstorage:framed_${size}` });
+            event.shapeless(`1x functionalstorage:framed_${size}`, [`1x #functionalstorage:drawer_size_${size}`, 'framedblocks:framed_hammer']).id(`start:shapeless/framed_drawer_${size}`);
+        })
+        event.shapeless('1x functionalstorage:framed_storage_controller', ['functionalstorage:storage_controller', 'framedblocks:framed_hammer']);
+    }, () => {
+        [
+            '1',
+            '2',
+            '4'
+        ].forEach(size => {
+            event.remove({ output: `functionalstorage:framed_${size}` });
+            event.shapeless(`1x functionalstorage:framed_${size}`, [`1x #functionalstorage:drawer_size_${size}`, '#forge:tools/hammers']).id(`start:shapeless/framed_drawer_${size}`);
+        })
+        event.shapeless('1x functionalstorage:framed_storage_controller', ['functionalstorage:storage_controller', '#forge:tools/hammers']);
+    });
 
     event.shaped('1x functionalstorage:redstone_upgrade', [
         ' R ',

--- a/kubejs/server_scripts/common/modifications/general.js
+++ b/kubejs/server_scripts/common/modifications/general.js
@@ -78,6 +78,7 @@ ServerEvents.recipes(event => {
     }).id('start:shaped/advanced_wireless_terminal');
 
     // Effortless Building Upgrade Accessibility
+    global.with_effortlessbuilding(() => {
     const reachUpgrade = (type,mat,dye,core) => {
         event.remove({output: `effortlessbuilding:reach_upgrade${type}`});
         event.shaped(Item.of(`effortlessbuilding:reach_upgrade${type}`), [
@@ -94,6 +95,7 @@ ServerEvents.recipes(event => {
     reachUpgrade('1','minecraft:slime_ball','minecraft:lime_dye',`minecraft:ender_pearl`);
     reachUpgrade('2','minecraft:glowstone_dust','minecraft:orange_dye',`effortlessbuilding:reach_upgrade1`);
     reachUpgrade('3','minecraft:amethyst_shard','minecraft:purple_dye',`effortlessbuilding:reach_upgrade2`);
+    });
 
     // Bingus
     event.shaped('bingus:floppa_orb', [

--- a/kubejs/server_scripts/common/modifications/project_red.js
+++ b/kubejs/server_scripts/common/modifications/project_red.js
@@ -1,4 +1,4 @@
-
+//requires: projectred_core
 ServerEvents.recipes(event => {
 
     const core = (id) => `projectred_core:${id}`;

--- a/kubejs/server_scripts/common/modifications/travel_anchors.js
+++ b/kubejs/server_scripts/common/modifications/travel_anchors.js
@@ -1,3 +1,4 @@
+//requires: travelanchors
 ServerEvents.recipes(event => {
     const id = global.id;
 

--- a/kubejs/server_scripts/common/modifications/xycraft.js
+++ b/kubejs/server_scripts/common/modifications/xycraft.js
@@ -1,3 +1,4 @@
+//requires: xycraft_world
 ServerEvents.recipes(event => {
     const id = global.id;
 

--- a/kubejs/server_scripts/common/systems/agriculture/tree_greenhouse.js
+++ b/kubejs/server_scripts/common/systems/agriculture/tree_greenhouse.js
@@ -1,7 +1,7 @@
 ServerEvents.recipes(event => {
     const id = global.id;
 
-    [
+    let woodTypes = [
         { name: 'oak', sapling: 'oak_sapling', namespace: 'minecraft'},
         { name: 'dark_oak', sapling: 'dark_oak_sapling', namespace: 'minecraft'},
         { name: 'birch', sapling: 'birch_sapling', namespace: 'minecraft'},
@@ -9,9 +9,12 @@ ServerEvents.recipes(event => {
         { name: 'acacia', sapling: 'acacia_sapling', namespace: 'minecraft'},
         { name: 'jungle', sapling: 'jungle_sapling', namespace: 'minecraft'},
         { name: 'cherry', sapling: 'cherry_sapling', namespace: 'minecraft'},
-        { name: 'mangrove', sapling: 'mangrove_propagule', namespace: 'minecraft'},
-        { name: 'twisted', sapling: 'twisted_sapling', namespace: 'architects_palette'},
-    ].forEach(type => {
+        { name: 'mangrove', sapling: 'mangrove_propagule', namespace: 'minecraft'}
+    ];
+    global.with_architects_palette(() => {
+        woodTypes.push({ name: 'twisted', sapling: 'twisted_sapling', namespace: 'architects_palette'});
+    })
+    woodTypes.forEach(type => {
         event.recipes.gtceu.tree_greenhouse(id(`${type.name}_growing`))
             .notConsumable(`${type.namespace}:${type.sapling}`)
             .itemOutputs(`16x ${type.namespace}:${type.name}_log`)

--- a/kubejs/server_scripts/default/additions/progression/early_game/sieving.js
+++ b/kubejs/server_scripts/default/additions/progression/early_game/sieving.js
@@ -197,13 +197,6 @@ global.not_hardmode(() => {
             .add('minecraft:sea_pickle', 0.05)
             .add('kelp', 0.15)
             .add('minecraft:seagrass', 0.15)
-            // Waterlogged Dust Sieving
-            .input(csi.dust)
-            .add('xycraft_world:xychorium_gem_blue', 0.75)
-            .add('xycraft_world:xychorium_gem_red', 0.75)
-            .add('xycraft_world:xychorium_gem_green', 0.75)
-            .add('xycraft_world:xychorium_gem_light', 0.75)
-            .add('xycraft_world:xychorium_gem_dark', 0.75)
             // Gravel Sieving
             .input(csi.gravel)
             .waterlogged(false)
@@ -258,7 +251,21 @@ global.not_hardmode(() => {
             .add('exnihilosequentia:dripstone_pebble', 0.05)
             .add('exnihilosequentia:granite_pebble', 0.05)
             .add('exnihilosequentia:stone_pebble', 0.05)
-            .add('exnihilosequentia:tuff_pebble', 0.05)
+            .add('exnihilosequentia:tuff_pebble', 0.05);
+
+        global.with_xycraft_world(() => {
+            // Waterlogged Dust Sieving
+            SievingRecipeHandler
+                .input(csi.dust)
+                .add('xycraft_world:xychorium_gem_blue', 0.75)
+                .add('xycraft_world:xychorium_gem_red', 0.75)
+                .add('xycraft_world:xychorium_gem_green', 0.75)
+                .add('xycraft_world:xychorium_gem_light', 0.75)
+                .add('xycraft_world:xychorium_gem_dark', 0.75);
+
+        });
+
+        SievingRecipeHandler
             .build(event);
 
         //Dirts

--- a/kubejs/server_scripts/default/modifications/item_collectors.js
+++ b/kubejs/server_scripts/default/modifications/item_collectors.js
@@ -1,3 +1,4 @@
+//requires: itemcollectors
 global.not_hardmode(() => {
 
     ServerEvents.recipes(event => {

--- a/kubejs/server_scripts/default/modifications/pipez.js
+++ b/kubejs/server_scripts/default/modifications/pipez.js
@@ -1,3 +1,4 @@
+//requires: pipez
 global.not_hardmode(() => {
 
     ServerEvents.recipes(event => {

--- a/kubejs/server_scripts/utils/helpers/recipe_helpers.js
+++ b/kubejs/server_scripts/utils/helpers/recipe_helpers.js
@@ -316,3 +316,32 @@ ServerEvents.recipes(event => {
   }
   
 });
+
+
+const modRequirements = {
+    architects_palette: 'architects_palette',
+    xycraft_world: 'xycraft_world',
+    chipped: 'chipped',
+    framedblocks: 'framedblocks',
+    effortlessbuilding: 'effortlessbuilding'
+};
+
+// Auto-generate all the wrapper functions
+// Similar to the packmode helpers
+Object.entries(modRequirements).forEach(([name, mod]) => {
+    const mods = Array.isArray(mod) ? mod : [mod];
+    /**
+     * @param {function} if_true - Function to execute if current mod is loaded'.
+     * @param {function} if_false - Function to execute if current mod is NOT loaded'.
+     */
+    global[`with_${name}`] = (if_true, if_false) => {
+        if (mods.every(m => Platform.isLoaded(m))) {
+          if (if_true && typeof if_true === 'function') {
+            if_true();
+          }
+        } else if (if_false && typeof if_false === 'function') {
+            if_false();
+        }
+    };
+});
+


### PR DESCRIPTION
## Description
Recipes that depend on small mods now only load when those mods are present. Previously, missing mod dependencies would cause errors. Methods are auto generated from a lookup table, so really easily expandable.

## QOL
This makes updating the modpack significantly easier — no more manually removing recipes or troubleshooting errors when a small decor mod is removed.

*Correction for 'https://github.com/StarT-Dev-Team/Star-Technology/pull/523'*