### PR TITLE
Add Trofers mod & integrate custom progression trophies for tech eras

### DIFF
--- a/compile_data/manifest.json
+++ b/compile_data/manifest.json
@@ -1147,6 +1147,12 @@
       "fileID": 6639933,
       "required": true,
       "isLocked": false
+    },
+    {
+      "projectID": 482265,
+      "fileID": 7164487,
+      "required": true,
+      "isLocked": false
     }
   ],
   "overrides": "overrides",

--- a/compile_data/modlist.html
+++ b/compile_data/modlist.html
@@ -188,4 +188,5 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/observable">Observable (by tasgon)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/defaultworldtype">Default World Type [Forge] (by MelanX)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/chisel-chipped-integration">Chisel Chipped Integration (by zSemper)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/trofers">Trofers (by ochotonida)</a></li>
 </ul>

--- a/config/ftbquests/quests/chapters/line_of_progression.snbt
+++ b/config/ftbquests/quests/chapters/line_of_progression.snbt
@@ -644,6 +644,19 @@
 				"123F0103224A8C43"
 			]
 			id: "6C6BD459EC785524"
+			rewards: [{
+				id: "65C3BB39B9048C4D"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:iv_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "02B80B4707C41992"
 				item: "kubejs:iv_universal_circuit"
@@ -655,6 +668,19 @@
 		{
 			dependencies: ["52FE319F5E176C37"]
 			id: "2C1F52216F0003E6"
+			rewards: [{
+				id: "7CD6B2D2FEF42F56"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:ev_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "7CD0CAE01546EEB9"
 				item: "kubejs:ev_universal_circuit"
@@ -666,6 +692,19 @@
 		{
 			dependencies: ["73931EAA3EC5C9A9"]
 			id: "4CDBB14A234A17CC"
+			rewards: [{
+				id: "7B445731B487633A"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:hv_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "62DFADAAB182EEAF"
 				item: "kubejs:hv_universal_circuit"
@@ -677,6 +716,19 @@
 		{
 			dependencies: ["7836F17B34B47B16"]
 			id: "5E106516E1301149"
+			rewards: [{
+				id: "5A48F28B6B562946"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:mv_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "60BB405CE6E39232"
 				item: "kubejs:mv_universal_circuit"
@@ -691,6 +743,19 @@
 				"4E1271A47BFEE3B9"
 			]
 			id: "088E1B8DCADB8E5F"
+			rewards: [{
+				id: "327BBC6255BC0A3F"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:lv_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "0663B9E066B17558"
 				item: "kubejs:lv_universal_circuit"
@@ -702,6 +767,19 @@
 		{
 			dependencies: ["3B81632EF4586280"]
 			id: "725838B2E5E0F1ED"
+			rewards: [{
+				id: "1F22C26BB206A1D7"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:ulv_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "03CF650CB7C72095"
 				item: "kubejs:ulv_universal_circuit"
@@ -713,6 +791,19 @@
 		{
 			dependencies: ["53A9F3758C218CDC"]
 			id: "780DE9C5FAC1A07B"
+			rewards: [{
+				id: "121231EE3D2307A5"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:luv_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "60F21FFB33D8FCB2"
 				item: "kubejs:luv_universal_circuit"
@@ -727,6 +818,19 @@
 				"26250BA1D20AE2DC"
 			]
 			id: "68F9735CB776A7A5"
+			rewards: [{
+				id: "05B657CE5E24F59F"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:zpm_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "5A0D53C0B8BFACF3"
 				item: "kubejs:zpm_universal_circuit"
@@ -738,6 +842,19 @@
 		{
 			dependencies: ["3FC351F05F2AC743"]
 			id: "0D4D54F0410EB78A"
+			rewards: [{
+				id: "2E0A2F9BF5C77E11"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:uv_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "753E7D945E8041B9"
 				item: "kubejs:uv_universal_circuit"
@@ -749,6 +866,19 @@
 		{
 			dependencies: ["707C2E9BA62A60C5"]
 			id: "435A9E0547D1D700"
+			rewards: [{
+				id: "32CC5BF89B894303"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:uhv_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "52E18B22878011BB"
 				item: "kubejs:uhv_universal_circuit"
@@ -761,6 +891,19 @@
 			dependencies: ["25583D0BF59E1BC8"]
 			id: "5584A2F87AC8631E"
 			optional: true
+			rewards: [{
+				id: "635D24D7195743F3"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:uev_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "58B4EB491E26C14B"
 				item: {
@@ -777,6 +920,19 @@
 			dependencies: ["5944C4DE27F98FF3"]
 			id: "73B54F4D395FB5EC"
 			optional: true
+			rewards: [{
+				id: "02CC64D999FE1B57"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:uiv_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "1581178AE7A9FA51"
 				item: {
@@ -922,6 +1078,19 @@
 		{
 			dependencies: ["3B1453C435E3950B"]
 			id: "0B105880E4EC0BD1"
+			rewards: [{
+				id: "739AFCCB817A30F7"
+				item: {
+					Count: 1
+					id: "trofers:large_pillar"
+					tag: {
+						BlockEntityTag: {
+							Trophy: "kubejs:uxv_trophy"
+						}
+					}
+				}
+				type: "item"
+			}]
 			tasks: [{
 				id: "6086AB2EA119E261"
 				item: "kubejs:uxv_universal_circuit"

--- a/config/trofers/general.json5
+++ b/config/trofers/general.json5
@@ -1,0 +1,8 @@
+{
+	// The chance an entity from a supported mod drops a trophy when killed
+	"trophyChance": 0,
+	// Whether trophies can drop loot when right-clicked
+	"enableTrophyLoot": false,
+	// Whether trophies can apply potion effects when right-clicked
+	"enableTrophyEffects": false
+}

--- a/kubejs/data/kubejs/trofers/ev_trophy.json
+++ b/kubejs/data/kubejs/trofers/ev_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§5§lEV Era Trophy",
+  "item": {
+    "item": "kubejs:ev_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#A800A8"
+  },
+  "effects": {},
+  "hidden": true
+}

--- a/kubejs/data/kubejs/trofers/hv_trophy.json
+++ b/kubejs/data/kubejs/trofers/hv_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§6§lHV Era Trophy",
+  "item": {
+    "item": "kubejs:hv_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#FCA900"
+  },
+  "effects": {},
+  "hidden": true
+}

--- a/kubejs/data/kubejs/trofers/iv_trophy.json
+++ b/kubejs/data/kubejs/trofers/iv_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§9§lIV Era Trophy",
+  "item": {
+    "item": "kubejs:iv_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#5454FD"
+  },
+  "effects": {},
+  "hidden": true
+}

--- a/kubejs/data/kubejs/trofers/luv_trophy.json
+++ b/kubejs/data/kubejs/trofers/luv_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§d§lLuV Era Trophy",
+  "item": {
+    "item": "kubejs:luv_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#FF55FF"
+  },
+  "effects": {},
+  "hidden": true
+}

--- a/kubejs/data/kubejs/trofers/lv_trophy.json
+++ b/kubejs/data/kubejs/trofers/lv_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§7§lLV Era Trophy",
+  "item": {
+    "item": "kubejs:lv_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#AAAAAA"
+  },
+  "effects": {},
+  "hidden": true
+}

--- a/kubejs/data/kubejs/trofers/mv_trophy.json
+++ b/kubejs/data/kubejs/trofers/mv_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§b§lMV Era Trophy",
+  "item": {
+    "item": "kubejs:mv_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#58FFFF"
+  },
+  "effects": {},
+  "hidden": true
+}

--- a/kubejs/data/kubejs/trofers/uev_trophy.json
+++ b/kubejs/data/kubejs/trofers/uev_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§a§lUEV Era Trophy",
+  "item": {
+    "item": "kubejs:uev_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#46D146"
+  },
+  "effects": {},
+  "hidden": true
+}

--- a/kubejs/data/kubejs/trofers/uhv_trophy.json
+++ b/kubejs/data/kubejs/trofers/uhv_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§4§lUHV Era Trophy",
+  "item": {
+    "item": "kubejs:uhv_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#A90000"
+  },
+  "effects": {},
+  "hidden": true
+}

--- a/kubejs/data/kubejs/trofers/uiv_trophy.json
+++ b/kubejs/data/kubejs/trofers/uiv_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§2§lUIV Era Trophy",
+  "item": {
+    "item": "kubejs:uiv_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#00AB00"
+  },
+  "effects": {},
+  "hidden": true
+}

--- a/kubejs/data/kubejs/trofers/ulv_trophy.json
+++ b/kubejs/data/kubejs/trofers/ulv_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§8§lULV Era Trophy",
+  "item": {
+    "item": "kubejs:ulv_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#545454"
+  },
+  "effects": {},
+  "hidden": true
+}

--- a/kubejs/data/kubejs/trofers/uv_trophy.json
+++ b/kubejs/data/kubejs/trofers/uv_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§3§lUV Era Trophy",
+  "item": {
+    "item": "kubejs:uv_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#00AAAA"
+  },
+  "effects": {},
+  "hidden": true
+}

--- a/kubejs/data/kubejs/trofers/uxv_trophy.json
+++ b/kubejs/data/kubejs/trofers/uxv_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§e§lUXV Era Trophy",
+  "item": {
+    "item": "kubejs:uxv_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#FCFC54"
+  },
+  "effects": {},
+  "hidden": true
+}

--- a/kubejs/data/kubejs/trofers/zpm_trophy.json
+++ b/kubejs/data/kubejs/trofers/zpm_trophy.json
@@ -1,0 +1,25 @@
+{
+  "name": "§c§lZPM Era Trophy",
+  "item": {
+    "item": "kubejs:zpm_universal_circuit",
+    "count": 1
+  },
+  "display": {
+    "scale": 1.2,
+    "offset": {
+      "x": 0.0,
+      "y": 2.5,
+      "z": 0.0
+    }
+  },
+  "animation": {
+    "type": "spinning",
+    "speed": 0.3
+  },
+  "colors": {
+    "base": "#6B6B6B",
+    "accent": "#FD5454"
+  },
+  "effects": {},
+  "hidden": true
+}


### PR DESCRIPTION
Hello! 

I have integrated the 'Trofers' mod into the pack and created custom progression trophies as rewards for completing the main tech eras.

Here is a quick summary of the changes:
- Created custom animated trophy configurations for eras via KubeJS.
- Disabled default Trofers mob drops.
- Linked the pillar trophies with proper custom NBT data as rewards directly into the FTB Quests progression line chapter.
- Updated `manifest.json` with the official Trofers project and file IDs for 1.20.1 Forge.

I have attached three screenshots below to demonstrate how it looks in-game:

1. **Showcase**: All trophies placed together on the base (showing their colors and spinning animation).
<img width="1621" height="916" alt="screen1" src="https://github.com/user-attachments/assets/9f6e3cb6-ed3a-44ee-8385-f94d8a242e22" />


2. **Item Display**: How the trophy looks when held in the hand, including its custom bold and tier-colored name tooltip.
<img width="579" height="288" alt="screen2" src="https://github.com/user-attachments/assets/f3e81268-f582-4e74-bb09-06d6ced1f781" />


3. **Quest Reward**: Proof of successful integration into the main progression line chapter rewards.
<img width="3400" height="1248" alt="screen3" src="https://github.com/user-attachments/assets/812292c5-4fc4-4cc0-8c15-a8a37df4187a" />




Please review the changes and let me know if any adjustments or future era additions are needed. Thank you for your time!