### PR TITLE
Adds KubeJS recipes to bulk copy Flux Networks configurations

### DIFF
--- a/kubejs/server_scripts/modifications/flux_networks.js
+++ b/kubejs/server_scripts/modifications/flux_networks.js
@@ -11,3 +11,40 @@ ServerEvents.recipes((event) => {
         .EUt(1024)
         .circuit(1);
 });
+
+ServerEvents.recipes((event) => {
+    const fluxItems = [
+        'fluxnetworks:flux_plug',
+        'fluxnetworks:flux_point',
+        'fluxnetworks:basic_flux_storage',
+        'fluxnetworks:herculean_flux_storage',
+        'fluxnetworks:gargantuan_flux_storage',
+    ];
+
+    fluxItems.forEach((id) => {
+        event
+            .shapeless(Item.of(id), ['fluxnetworks:flux_configurator', id])
+            .modifyResult((grid, result) => {
+                let fluxConfigurator = grid.find(Item.of('fluxnetworks:flux_configurator'));
+
+                if (!fluxConfigurator || !fluxConfigurator.nbt || !fluxConfigurator.nbt.FluxConfig) {
+                    return Item.of(id);
+                }
+
+                let data = fluxConfigurator.nbt.FluxConfig;
+                let newData = {
+                    FluxData: {
+                        limit: data.limit,
+                        networkID: data.networkID,
+                        priority: data.priority,
+                        disableLimit: data.disableLimit,
+                        surgeMode: data.surgeMode,
+                    },
+                };
+                let existingItemData = grid.find(Item.of(id)).nbt;
+
+                return Item.of(id).withNBT(existingItemData).withNBT(newData);
+            })
+            .keepIngredient('fluxnetworks:flux_configurator');
+    });
+});

--- a/kubejs/server_scripts/modifications/flux_networks.js
+++ b/kubejs/server_scripts/modifications/flux_networks.js
@@ -10,9 +10,7 @@ ServerEvents.recipes((event) => {
         .duration(2400)
         .EUt(1024)
         .circuit(1);
-});
-
-ServerEvents.recipes((event) => {
+    
     const fluxItems = [
         'fluxnetworks:flux_plug',
         'fluxnetworks:flux_point',


### PR DESCRIPTION
Adds shapeless recipes for plugs, points, and storage blocks.
Crafting a Flux Configurator with any of those items copies the configurator's NBT data (network ID, limits, priority, surge mode) onto the other item.

Any existing nbt on the item is left as is (so e.g., stored energy isn't wiped)